### PR TITLE
aligning the text in the middle (vertically)

### DIFF
--- a/library/scss/modules/_forms.scss
+++ b/library/scss/modules/_forms.scss
@@ -40,7 +40,7 @@ textarea,
 .field {
   display: block;
   height: 40px;
-  line-height: 40px;
+  line-height: 1em;
   padding: 0 12px;
   margin-bottom: 14px;
   font-size: 1em;


### PR DESCRIPTION
the 40px just made it stick to the bottom. however, with 1em, you can change the height of the input and the text inside will always stay in the middle. (vertically)