### PR TITLE
on footer.php .footer-links tag doesn't exist

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -4,16 +4,16 @@
 
 					<nav role="navigation">
 						<?php wp_nav_menu(array(
-    					'container' => '',                              // remove nav container
+    					'container' => 'div',                           // enter '' to remove nav container (just make sure .footer-links in _base.scss isn't wrapping)
     					'container_class' => 'footer-links cf',         // class of container (should you choose to use it)
     					'menu' => __( 'Footer Links', 'bonestheme' ),   // nav name
     					'menu_class' => 'nav footer-nav cf',            // adding custom nav class
     					'theme_location' => 'footer-links',             // where it's located in the theme
     					'before' => '',                                 // before the menu
-        			'after' => '',                                  // after the menu
-        			'link_before' => '',                            // before each link
-        			'link_after' => '',                             // after each link
-        			'depth' => 0,                                   // limit the depth of the nav
+    					'after' => '',                                  // after the menu
+    					'link_before' => '',                            // before each link
+    					'link_after' => '',                             // after each link
+    					'depth' => 0,                                   // limit the depth of the nav
     					'fallback_cb' => 'bones_footer_links_fallback'  // fallback function
 						)); ?>
 					</nav>


### PR DESCRIPTION
On _base.sass the ```.footer-links``` is wrapping everything, therefore, it should exist in the footer.php file too.

the existing _base.sass code:
```
	.footer-links {
		ul {
			li {
			}
		}
	} /* end .footer-links */
```

either will work:
* remove ```.footer-links``` class container in the _base.sass file
* or add the HTML tag (```<div class="footer-links">```) in footer.php