### PR TITLE
fix broken pagination

### DIFF
--- a/library/bones.php
+++ b/library/bones.php
@@ -261,7 +261,7 @@ function bones_page_navi() {
     return;
   echo '<nav class="pagination">';
   echo paginate_links( array(
-    'base'         => str_replace( $bignum, '%#%', esc_url( get_pagenum_link($bignum) ) ),
+    'base'         => str_replace( $bignum, '%#%', html_entity_decode( get_pagenum_link($bignum) ) ),
     'format'       => '',
     'current'      => max( 1, get_query_var('paged') ),
     'total'        => $wp_query->max_num_pages,

--- a/library/bones.php
+++ b/library/bones.php
@@ -261,7 +261,7 @@ function bones_page_navi() {
     return;
   echo '<nav class="pagination">';
   echo paginate_links( array(
-    'base'         => str_replace( $bignum, '%#%', html_entity_decode( get_pagenum_link($bignum) ) ),
+    'base'         => str_replace( $bignum, '%#%', esc_url( get_pagenum_link($bignum) ) ),
     'format'       => '',
     'current'      => max( 1, get_query_var('paged') ),
     'total'        => $wp_query->max_num_pages,
@@ -269,7 +269,8 @@ function bones_page_navi() {
     'next_text'    => '&rarr;',
     'type'         => 'list',
     'end_size'     => 3,
-    'mid_size'     => 3
+    'mid_size'     => 3,
+    'add_args'     => false
   ) );
   echo '</nav>';
 } /* end page navi */


### PR DESCRIPTION
replaced esc_url with html_entity_decode in bones_page_navi() - this
fixes the broken pagination for non-pretty-permalinks as described in
#730