### PR TITLE
Fix whitespace and indentation

### DIFF
--- a/404.php
+++ b/404.php
@@ -22,13 +22,13 @@
 
 							<section class="search">
 
-									<p><?php get_search_form(); ?></p>
+								<p><?php get_search_form(); ?></p>
 
 							</section>
 
 							<footer class="article-footer">
 
-									<p><?php _e( 'This is the 404.php template.', 'bonestheme' ); ?></p>
+								<p><?php _e( 'This is the 404.php template.', 'bonestheme' ); ?></p>
 
 							</footer>
 

--- a/archive-custom_type.php
+++ b/archive-custom_type.php
@@ -5,7 +5,7 @@
  * This is the custom post type archive template. If you edit the custom post type name,
  * you've got to change the name of this template to reflect that name change.
  *
- * For Example, if your custom post type is called "register_post_type( 'bookmarks')",
+ * For example, if your custom post type is called "register_post_type( 'bookmarks ')",
  * then your template name should be archive-bookmarks.php
  *
  * For more info: http://codex.wordpress.org/Post_Type_Templates
@@ -22,52 +22,63 @@
 
 						<h1 class="archive-title h2"><?php post_type_archive_title(); ?></h1>
 
-							<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+						<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 
-							<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article">
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article">
 
-								<header class="article-header">
+							<header class="article-header">
 
-									<h3 class="h2"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h3>
-									<p class="byline vcard"><?php
-										printf( __( 'Posted <time class="updated" datetime="%1$s" itemprop="datePublished">%2$s</time> by <span class="author">%3$s</span>', 'bonestheme' ), get_the_time( 'Y-m-j' ), get_the_time( __( 'F jS, Y', 'bonestheme' ) ), get_author_posts_url( get_the_author_meta( 'ID' ) ));
-									?></p>
+								<h3 class="h2"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h3>
+								
+								<p class="byline vcard"><?php
 
-								</header>
+								 	printf( __( 'Posted <time class="updated" datetime="%1$s" itemprop="datePublished">%2$s</time> by <span class="author">%3$s</span>', 'bonestheme' ), get_the_time( 'Y-m-j' ), get_the_time( __( 'F jS, Y', 'bonestheme' ) ), get_author_posts_url( get_the_author_meta( 'ID' ) )); 
 
-								<section class="entry-content cf">
+							 	?></p>
 
-									<?php the_excerpt(); ?>
+							</header>
 
-								</section>
+							<section class="entry-content cf">
 
-								<footer class="article-footer">
+								<?php the_excerpt(); ?>
 
-								</footer>
+							</section>
 
-							</article>
+							<footer class="article-footer"></footer>
 
-							<?php endwhile; ?>
+						</article>
 
-									<?php bones_page_navi(); ?>
+						<?php endwhile; ?>
 
-							<?php else : ?>
+						<?php bones_page_navi(); ?>
 
-									<article id="post-not-found" class="hentry cf">
-										<header class="article-header">
-											<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
-										</header>
-										<section class="entry-content">
-											<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
-										</section>
-										<footer class="article-footer">
-												<p><?php _e( 'This is the error message in the custom posty type archive template.', 'bonestheme' ); ?></p>
-										</footer>
-									</article>
+						<?php else : ?>
 
-							<?php endif; ?>
+						<article id="post-not-found" class="hentry cf">
 
-						</main>
+							<header class="article-header">
+
+								<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
+
+							</header>
+
+							<section class="entry-content">
+
+								<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
+
+							</section>
+
+							<footer class="article-footer">
+
+								<p><?php _e( 'This is the error message in the custom posty type archive template.', 'bonestheme' ); ?></p>
+
+							</footer>
+
+						</article>
+
+						<?php endif; ?>
+
+					</main>
 
 					<?php get_sidebar(); ?>
 

--- a/archive.php
+++ b/archive.php
@@ -4,96 +4,101 @@
 
 				<div id="inner-content" class="wrap cf">
 
-						<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
+					<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
 
-							<?php if (is_category()) { ?>
-								<h1 class="archive-title h2">
-									<span><?php _e( 'Posts Categorized:', 'bonestheme' ); ?></span> <?php single_cat_title(); ?>
-								</h1>
+						<?php if ( is_category() ) : ?>
 
-							<?php } elseif (is_tag()) { ?>
-								<h1 class="archive-title h2">
-									<span><?php _e( 'Posts Tagged:', 'bonestheme' ); ?></span> <?php single_tag_title(); ?>
-								</h1>
+						<h1 class="archive-title h2"><span><?php _e( 'Posts Categorized:', 'bonestheme' ); ?></span> <?php single_cat_title(); ?></h1>
 
-							<?php } elseif (is_author()) {
-								global $post;
-								$author_id = $post->post_author;
-							?>
-								<h1 class="archive-title h2">
+						<?php elseif ( is_tag() ) : ?>
 
-									<span><?php _e( 'Posts By:', 'bonestheme' ); ?></span> <?php the_author_meta('display_name', $author_id); ?>
+						<h1 class="archive-title h2"><span><?php _e( 'Posts Tagged:', 'bonestheme' ); ?></span> <?php single_tag_title(); ?></h1>
 
-								</h1>
-							<?php } elseif (is_day()) { ?>
-								<h1 class="archive-title h2">
-									<span><?php _e( 'Daily Archives:', 'bonestheme' ); ?></span> <?php the_time('l, F j, Y'); ?>
-								</h1>
+						<?php elseif ( is_author() ) :
+							global $post;
+							$author_id = $post->post_author;
+						?>
 
-							<?php } elseif (is_month()) { ?>
-									<h1 class="archive-title h2">
-										<span><?php _e( 'Monthly Archives:', 'bonestheme' ); ?></span> <?php the_time('F Y'); ?>
-									</h1>
+						<h1 class="archive-title h2"><span><?php _e( 'Posts By:', 'bonestheme' ); ?></span> <?php the_author_meta( 'display_name', $author_id ); ?></h1>
 
-							<?php } elseif (is_year()) { ?>
-									<h1 class="archive-title h2">
-										<span><?php _e( 'Yearly Archives:', 'bonestheme' ); ?></span> <?php the_time('Y'); ?>
-									</h1>
-							<?php } ?>
+						<?php elseif ( is_day() ) : ?>
 
-							<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+						<h1 class="archive-title h2"><span><?php _e( 'Daily Archives:', 'bonestheme' ); ?></span> <?php the_time( 'l, F j, Y' ); ?></h1>
 
-							<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article">
+						<?php elseif ( is_month() ) : ?>
 
-								<header class="entry-header article-header">
+						<h1 class="archive-title h2"><span><?php _e( 'Monthly Archives:', 'bonestheme' ); ?></span> <?php the_time( 'F Y' ); ?></h1>
 
-									<h3 class="h2 entry-title"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h3>
-									<p class="byline entry-meta vcard">
-										<?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                  							     /* the time the post was published */
-                  							     '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       								/* the author of the post */
-                       								'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    							); ?>
-									</p>
+						<?php elseif ( is_year() ) : ?>
 
-								</header>
+						<h1 class="archive-title h2"><span><?php _e( 'Yearly Archives:', 'bonestheme' ); ?></span> <?php the_time( 'Y' ); ?></h1>
 
-								<section class="entry-content cf">
+						<?php endif; ?>
 
-									<?php the_post_thumbnail( 'bones-thumb-300' ); ?>
+						<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 
-									<?php the_excerpt(); ?>
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article">
 
-								</section>
+							<header class="entry-header article-header">
 
-								<footer class="article-footer">
+								<h3 class="h2 entry-title"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h3>
+								
+								<p class="byline entry-meta vcard"><?php 
 
-								</footer>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									);
 
-							</article>
+								?></p>
 
-							<?php endwhile; ?>
+							</header>
 
-									<?php bones_page_navi(); ?>
+							<section class="entry-content cf">
 
-							<?php else : ?>
+								<?php the_post_thumbnail( 'bones-thumb-300' ); ?>
 
-									<article id="post-not-found" class="hentry cf">
-										<header class="article-header">
-											<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
-										</header>
-										<section class="entry-content">
-											<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
-										</section>
-										<footer class="article-footer">
-												<p><?php _e( 'This is the error message in the archive.php template.', 'bonestheme' ); ?></p>
-										</footer>
-									</article>
+								<?php the_excerpt(); ?>
 
-							<?php endif; ?>
+							</section>
 
-						</main>
+							<footer class="article-footer"></footer>
+
+						</article>
+
+						<?php endwhile; ?>
+
+						<?php bones_page_navi(); ?>
+
+						<?php else : ?>
+
+						<article id="post-not-found" class="hentry cf">
+
+							<header class="article-header">
+
+								<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
+
+							</header>
+
+							<section class="entry-content">
+
+								<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
+
+							</section>
+
+							<footer class="article-footer">
+
+								<p><?php _e( 'This is the error message in the archive.php template.', 'bonestheme' ); ?></p>
+
+							</footer>
+
+						</article>
+
+						<?php endif; ?>
+
+					</main>
 
 					<?php get_sidebar(); ?>
 

--- a/archive.php
+++ b/archive.php
@@ -49,7 +49,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									);
 
 								?></p>

--- a/comments.php
+++ b/comments.php
@@ -5,46 +5,54 @@ The comments page for Bones
 
 // don't load it if you can't comment
 if ( post_password_required() ) {
-  return;
+	return;
 }
 
 ?>
 
 <?php // You can start editing here. ?>
 
-  <?php if ( have_comments() ) : ?>
+<?php if ( have_comments() ) : ?>
 
-    <h3 id="comments-title" class="h2"><?php comments_number( __( '<span>No</span> Comments', 'bonestheme' ), __( '<span>One</span> Comment', 'bonestheme' ), __( '<span>%</span> Comments', 'bonestheme' ) );?></h3>
+	<h3 id="comments-title" class="h2"><?php comments_number( __( '<span>No</span> Comments', 'bonestheme' ), __( '<span>One</span> Comment', 'bonestheme' ), __( '<span>%</span> Comments', 'bonestheme' ) );?></h3>
 
-    <section class="commentlist">
-      <?php
-        wp_list_comments( array(
-          'style'             => 'div',
-          'short_ping'        => true,
-          'avatar_size'       => 40,
-          'callback'          => 'bones_comments',
-          'type'              => 'all',
-          'reply_text'        => __('Reply', 'bonestheme'),
-          'page'              => '',
-          'per_page'          => '',
-          'reverse_top_level' => null,
-          'reverse_children'  => ''
-        ) );
-      ?>
-    </section>
+	<section class="commentlist">
 
-    <?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : ?>
-    	<nav class="navigation comment-navigation" role="navigation">
-      	<div class="comment-nav-prev"><?php previous_comments_link( __( '&larr; Previous Comments', 'bonestheme' ) ); ?></div>
-      	<div class="comment-nav-next"><?php next_comments_link( __( 'More Comments &rarr;', 'bonestheme' ) ); ?></div>
-    	</nav>
-    <?php endif; ?>
+		<?php
+			wp_list_comments( array(
+				'style'             => 'div',
+				'short_ping'        => true,
+				'avatar_size'       => 40,
+				'callback'          => 'bones_comments',
+				'type'              => 'all',
+				'reply_text'        => __('Reply', 'bonestheme'),
+				'page'              => '',
+				'per_page'          => '',
+				'reverse_top_level' => null,
+				'reverse_children'  => ''
+			) );
+		?>
 
-    <?php if ( ! comments_open() ) : ?>
-    	<p class="no-comments"><?php _e( 'Comments are closed.' , 'bonestheme' ); ?></p>
-    <?php endif; ?>
+	</section>
 
-  <?php endif; ?>
+	<?php if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) : ?>
 
-  <?php comment_form(); ?>
+		<nav class="navigation comment-navigation" role="navigation">
 
+			<div class="comment-nav-prev"><?php previous_comments_link( __( '&larr; Previous Comments', 'bonestheme' ) ); ?></div>
+
+			<div class="comment-nav-next"><?php next_comments_link( __( 'More Comments &rarr;', 'bonestheme' ) ); ?></div>
+
+		</nav>
+
+	<?php endif; ?>
+
+	<?php if ( ! comments_open() ) : ?>
+
+		<p class="no-comments"><?php _e( 'Comments are closed.' , 'bonestheme' ); ?></p>
+
+	<?php endif; ?>
+
+<?php endif; ?>
+
+<?php comment_form(); ?>

--- a/footer.php
+++ b/footer.php
@@ -3,22 +3,24 @@
 				<div id="inner-footer" class="wrap cf">
 
 					<nav role="navigation">
-						<?php wp_nav_menu(array(
-    					'container' => 'div',                           // enter '' to remove nav container (just make sure .footer-links in _base.scss isn't wrapping)
-    					'container_class' => 'footer-links cf',         // class of container (should you choose to use it)
-    					'menu' => __( 'Footer Links', 'bonestheme' ),   // nav name
-    					'menu_class' => 'nav footer-nav cf',            // adding custom nav class
-    					'theme_location' => 'footer-links',             // where it's located in the theme
-    					'before' => '',                                 // before the menu
-    					'after' => '',                                  // after the menu
-    					'link_before' => '',                            // before each link
-    					'link_after' => '',                             // after each link
-    					'depth' => 0,                                   // limit the depth of the nav
-    					'fallback_cb' => 'bones_footer_links_fallback'  // fallback function
-						)); ?>
+
+						<?php wp_nav_menu( array(
+							'container'       => 'div',                              // enter '' to remove nav container (just make sure .footer-links in _base.scss isn't wrapping)
+							'container_class' => 'footer-links cf',                  // class of container (should you choose to use it)
+							'menu'            => __( 'Footer Links', 'bonestheme' ), // nav name
+							'menu_class'      => 'nav footer-nav cf',                // adding custom nav class
+							'theme_location'  => 'footer-links',                     // where it's located in the theme
+							'before'          => '',                                 // before the menu
+							'after'           => '',                                 // after the menu
+							'link_before'     => '',                                 // before each link
+							'link_after'      => '',                                 // after each link
+							'depth'           => 0,                                  // limit the depth of the nav
+							'fallback_cb'     => 'bones_footer_links_fallback',      // fallback function
+						) ); ?>
+
 					</nav>
 
-					<p class="source-org copyright">&copy; <?php echo date('Y'); ?> <?php bloginfo( 'name' ); ?>.</p>
+					<p class="source-org copyright">&copy; <?php echo date( 'Y' ); ?> <?php bloginfo( 'name' ); ?>.</p>
 
 				</div>
 

--- a/functions.php
+++ b/functions.php
@@ -248,7 +248,9 @@ add_action('wp_enqueue_scripts', 'bones_fonts');
 add_theme_support( 'html5', array(
 	'comment-list',
 	'search-form',
-	'comment-form'
+	'comment-form',
+	'gallery',
+	'caption',
 ) );
 
 /* DON'T DELETE THIS CLOSING TAG */ ?>

--- a/functions.php
+++ b/functions.php
@@ -21,42 +21,42 @@ Let's get everything up and running.
 
 function bones_ahoy() {
 
-  //Allow editor style.
-  add_editor_style( get_stylesheet_directory_uri() . '/library/css/editor-style.css' );
+	//Allow editor style.
+	add_editor_style( get_stylesheet_directory_uri() . '/library/css/editor-style.css' );
 
-  // let's get language support going, if you need it
-  load_theme_textdomain( 'bonestheme', get_template_directory() . '/library/translation' );
+	// let's get language support going, if you need it
+	load_theme_textdomain( 'bonestheme', get_template_directory() . '/library/translation' );
 
-  // USE THIS TEMPLATE TO CREATE CUSTOM POST TYPES EASILY
-  require_once( 'library/custom-post-type.php' );
+	// USE THIS TEMPLATE TO CREATE CUSTOM POST TYPES EASILY
+	require_once( 'library/custom-post-type.php' );
 
-  // launching operation cleanup
-  add_action( 'init', 'bones_head_cleanup' );
-  // A better title
-  add_filter( 'wp_title', 'rw_title', 10, 3 );
-  // remove WP version from RSS
-  add_filter( 'the_generator', 'bones_rss_version' );
-  // remove pesky injected css for recent comments widget
-  add_filter( 'wp_head', 'bones_remove_wp_widget_recent_comments_style', 1 );
-  // clean up comment styles in the head
-  add_action( 'wp_head', 'bones_remove_recent_comments_style', 1 );
-  // clean up gallery output in wp
-  add_filter( 'gallery_style', 'bones_gallery_style' );
+	// launching operation cleanup
+	add_action( 'init', 'bones_head_cleanup' );
+	// A better title
+	add_filter( 'wp_title', 'rw_title', 10, 3 );
+	// remove WP version from RSS
+	add_filter( 'the_generator', 'bones_rss_version' );
+	// remove pesky injected css for recent comments widget
+	add_filter( 'wp_head', 'bones_remove_wp_widget_recent_comments_style', 1 );
+	// clean up comment styles in the head
+	add_action( 'wp_head', 'bones_remove_recent_comments_style', 1 );
+	// clean up gallery output in wp
+	add_filter( 'gallery_style', 'bones_gallery_style' );
 
-  // enqueue base scripts and styles
-  add_action( 'wp_enqueue_scripts', 'bones_scripts_and_styles', 999 );
-  // ie conditional wrapper
+	// enqueue base scripts and styles
+	add_action( 'wp_enqueue_scripts', 'bones_scripts_and_styles', 999 );
+	// ie conditional wrapper
 
-  // launching this stuff after theme setup
-  bones_theme_support();
+	// launching this stuff after theme setup
+	bones_theme_support();
 
-  // adding sidebars to Wordpress (these are created in functions.php)
-  add_action( 'widgets_init', 'bones_register_sidebars' );
+	// adding sidebars to Wordpress (these are created in functions.php)
+	add_action( 'widgets_init', 'bones_register_sidebars' );
 
-  // cleaning up random code around images
-  add_filter( 'the_content', 'bones_filter_ptags_on_images' );
-  // cleaning up excerpt
-  add_filter( 'excerpt_more', 'bones_excerpt_more' );
+	// cleaning up random code around images
+	add_filter( 'the_content', 'bones_filter_ptags_on_images' );
+	// cleaning up excerpt
+	add_filter( 'excerpt_more', 'bones_excerpt_more' );
 
 } /* end bones ahoy */
 
@@ -99,10 +99,10 @@ you like. Enjoy!
 add_filter( 'image_size_names_choose', 'bones_custom_image_sizes' );
 
 function bones_custom_image_sizes( $sizes ) {
-    return array_merge( $sizes, array(
-        'bones-thumb-600' => __('600px by 150px'),
-        'bones-thumb-300' => __('300px by 100px'),
-    ) );
+	return array_merge( $sizes, array(
+			'bones-thumb-600' => __('600px by 150px'),
+			'bones-thumb-300' => __('300px by 100px'),
+	) );
 }
 
 /*
@@ -116,36 +116,36 @@ new image size.
 /************* THEME CUSTOMIZE *********************/
 
 /* 
-  A good tutorial for creating your own Sections, Controls and Settings:
-  http://code.tutsplus.com/series/a-guide-to-the-wordpress-theme-customizer--wp-33722
-  
-  Good articles on modifying the default options:
-  http://natko.com/changing-default-wordpress-theme-customization-api-sections/
-  http://code.tutsplus.com/tutorials/digging-into-the-theme-customizer-components--wp-27162
-  
-  To do:
-  - Create a js for the postmessage transport method
-  - Create some sanitize functions to sanitize inputs
-  - Create some boilerplate Sections, Controls and Settings
+	A good tutorial for creating your own Sections, Controls and Settings:
+	http://code.tutsplus.com/series/a-guide-to-the-wordpress-theme-customizer--wp-33722
+	
+	Good articles on modifying the default options:
+	http://natko.com/changing-default-wordpress-theme-customization-api-sections/
+	http://code.tutsplus.com/tutorials/digging-into-the-theme-customizer-components--wp-27162
+	
+	To do:
+	- Create a js for the postmessage transport method
+	- Create some sanitize functions to sanitize inputs
+	- Create some boilerplate Sections, Controls and Settings
 */
 
 function bones_theme_customizer($wp_customize) {
-  // $wp_customize calls go here.
-  //
-  // Uncomment the below lines to remove the default customize sections 
+	// $wp_customize calls go here.
+	//
+	// Uncomment the below lines to remove the default customize sections 
 
-  // $wp_customize->remove_section('title_tagline');
-  // $wp_customize->remove_section('colors');
-  // $wp_customize->remove_section('background_image');
-  // $wp_customize->remove_section('static_front_page');
-  // $wp_customize->remove_section('nav');
+	// $wp_customize->remove_section('title_tagline');
+	// $wp_customize->remove_section('colors');
+	// $wp_customize->remove_section('background_image');
+	// $wp_customize->remove_section('static_front_page');
+	// $wp_customize->remove_section('nav');
 
-  // Uncomment the below lines to remove the default controls
-  // $wp_customize->remove_control('blogdescription');
-  
-  // Uncomment the following to change the default section titles
-  // $wp_customize->get_section('colors')->title = __( 'Theme Colors' );
-  // $wp_customize->get_section('background_image')->title = __( 'Images' );
+	// Uncomment the below lines to remove the default controls
+	// $wp_customize->remove_control('blogdescription');
+	
+	// Uncomment the following to change the default section titles
+	// $wp_customize->get_section('colors')->title = __( 'Theme Colors' );
+	// $wp_customize->get_section('background_image')->title = __( 'Images' );
 }
 
 add_action( 'customize_register', 'bones_theme_customizer' );
@@ -154,7 +154,7 @@ add_action( 'customize_register', 'bones_theme_customizer' );
 
 // Sidebars & Widgetizes Areas
 function bones_register_sidebars() {
-	register_sidebar(array(
+	register_sidebar( array(
 		'id' => 'sidebar1',
 		'name' => __( 'Sidebar 1', 'bonestheme' ),
 		'description' => __( 'The first (primary) sidebar.', 'bonestheme' ),
@@ -162,7 +162,7 @@ function bones_register_sidebars() {
 		'after_widget' => '</div>',
 		'before_title' => '<h4 class="widgettitle">',
 		'after_title' => '</h4>',
-	));
+	) );
 
 	/*
 	to add more sidebars or widgetized areas, just copy
@@ -172,7 +172,7 @@ function bones_register_sidebars() {
 	Just change the name to whatever your new
 	sidebar's id is, for example:
 
-	register_sidebar(array(
+	register_sidebar( array(
 		'id' => 'sidebar2',
 		'name' => __( 'Sidebar 2', 'bonestheme' ),
 		'description' => __( 'The second (secondary) sidebar.', 'bonestheme' ),
@@ -180,7 +180,7 @@ function bones_register_sidebars() {
 		'after_widget' => '</div>',
 		'before_title' => '<h4 class="widgettitle">',
 		'after_title' => '</h4>',
-	));
+	) );
 
 	To call the sidebar in your template, you can just copy
 	the sidebar.php file and rename it to your sidebar's name.
@@ -195,38 +195,38 @@ function bones_register_sidebars() {
 
 // Comment Layout
 function bones_comments( $comment, $args, $depth ) {
-   $GLOBALS['comment'] = $comment; ?>
-  <div id="comment-<?php comment_ID(); ?>" <?php comment_class('cf'); ?>>
-    <article  class="cf">
-      <header class="comment-author vcard">
-        <?php
-        /*
-          this is the new responsive optimized comment image. It used the new HTML5 data-attribute to display comment gravatars on larger screens only. What this means is that on larger posts, mobile sites don't have a ton of requests for comment images. This makes load time incredibly fast! If you'd like to change it back, just replace it with the regular wordpress gravatar call:
-          echo get_avatar($comment,$size='32',$default='<path_to_url>' );
-        */
-        ?>
-        <?php // custom gravatar call ?>
-        <?php
-          // create variable
-          $bgauthemail = get_comment_author_email();
-        ?>
-        <img data-gravatar="http://www.gravatar.com/avatar/<?php echo md5( $bgauthemail ); ?>?s=40" class="load-gravatar avatar avatar-48 photo" height="40" width="40" src="<?php echo get_template_directory_uri(); ?>/library/images/nothing.gif" />
-        <?php // end custom gravatar call ?>
-        <?php printf(__( '<cite class="fn">%1$s</cite> %2$s', 'bonestheme' ), get_comment_author_link(), edit_comment_link(__( '(Edit)', 'bonestheme' ),'  ','') ) ?>
-        <time datetime="<?php echo comment_time('Y-m-j'); ?>"><a href="<?php echo htmlspecialchars( get_comment_link( $comment->comment_ID ) ) ?>"><?php comment_time(__( 'F jS, Y', 'bonestheme' )); ?> </a></time>
+	$GLOBALS['comment'] = $comment; ?>
+	<div id="comment-<?php comment_ID(); ?>" <?php comment_class('cf'); ?>>
+		<article  class="cf">
+			<header class="comment-author vcard">
+				<?php
+				/*
+					this is the new responsive optimized comment image. It used the new HTML5 data-attribute to display comment gravatars on larger screens only. What this means is that on larger posts, mobile sites don't have a ton of requests for comment images. This makes load time incredibly fast! If you'd like to change it back, just replace it with the regular wordpress gravatar call:
+					echo get_avatar($comment,$size='32',$default='<path_to_url>' );
+				*/
+				?>
+				<?php // custom gravatar call ?>
+				<?php
+					// create variable
+					$bgauthemail = get_comment_author_email();
+				?>
+				<img data-gravatar="http://www.gravatar.com/avatar/<?php echo md5( $bgauthemail ); ?>?s=40" class="load-gravatar avatar avatar-48 photo" height="40" width="40" src="<?php echo get_template_directory_uri(); ?>/library/images/nothing.gif" />
+				<?php // end custom gravatar call ?>
+				<?php printf(__( '<cite class="fn">%1$s</cite> %2$s', 'bonestheme' ), get_comment_author_link(), edit_comment_link(__( '(Edit)', 'bonestheme' ),'  ','') ) ?>
+				<time datetime="<?php echo comment_time('Y-m-j'); ?>"><a href="<?php echo htmlspecialchars( get_comment_link( $comment->comment_ID ) ) ?>"><?php comment_time(__( 'F jS, Y', 'bonestheme' )); ?> </a></time>
 
-      </header>
-      <?php if ($comment->comment_approved == '0') : ?>
-        <div class="alert alert-info">
-          <p><?php _e( 'Your comment is awaiting moderation.', 'bonestheme' ) ?></p>
-        </div>
-      <?php endif; ?>
-      <section class="comment_content cf">
-        <?php comment_text() ?>
-      </section>
-      <?php comment_reply_link(array_merge( $args, array('depth' => $depth, 'max_depth' => $args['max_depth']))) ?>
-    </article>
-  <?php // </li> is added by WordPress automatically ?>
+			</header>
+			<?php if ($comment->comment_approved == '0') : ?>
+				<div class="alert alert-info">
+					<p><?php _e( 'Your comment is awaiting moderation.', 'bonestheme' ) ?></p>
+				</div>
+			<?php endif; ?>
+			<section class="comment_content cf">
+				<?php comment_text() ?>
+			</section>
+			<?php comment_reply_link(array_merge( $args, array('depth' => $depth, 'max_depth' => $args['max_depth']))) ?>
+		</article>
+	<?php // </li> is added by WordPress automatically ?>
 <?php
 } // don't remove this bracket!
 
@@ -239,16 +239,16 @@ can replace these fonts, change it in your scss files
 and be up and running in seconds.
 */
 function bones_fonts() {
-  wp_enqueue_style('googleFonts', 'http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic');
+	wp_enqueue_style('googleFonts', 'http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic');
 }
 
 add_action('wp_enqueue_scripts', 'bones_fonts');
 
 // Enable support for HTML5 markup.
-	add_theme_support( 'html5', array(
-		'comment-list',
-		'search-form',
-		'comment-form'
-	) );
+add_theme_support( 'html5', array(
+	'comment-list',
+	'search-form',
+	'comment-form'
+) );
 
 /* DON'T DELETE THIS CLOSING TAG */ ?>

--- a/header.php
+++ b/header.php
@@ -11,12 +11,12 @@
 		<?php // force Internet Explorer to use the latest rendering engine available ?>
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-		<title><?php wp_title(''); ?></title>
+		<title><?php wp_title( '' ); ?></title>
 
 		<?php // mobile meta (hooray!) ?>
 		<meta name="HandheldFriendly" content="True">
 		<meta name="MobileOptimized" content="320">
-		<meta name="viewport" content="width=device-width, initial-scale=1"/>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 
 		<?php // icons & favicons (for more: http://www.jonathantneal.com/blog/understand-the-favicon/) ?>
 		<link rel="apple-touch-icon" href="<?php echo get_template_directory_uri(); ?>/library/images/apple-touch-icon.png">
@@ -27,9 +27,9 @@
 		<?php // or, set /favicon.ico for IE10 win ?>
 		<meta name="msapplication-TileColor" content="#f01d4f">
 		<meta name="msapplication-TileImage" content="<?php echo get_template_directory_uri(); ?>/library/images/win8-tile-icon.png">
-            <meta name="theme-color" content="#121212">
+		<meta name="theme-color" content="#121212">
 
-		<link rel="pingback" href="<?php bloginfo('pingback_url'); ?>">
+		<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 
 		<?php // wordpress head functions ?>
 		<?php wp_head(); ?>
@@ -48,27 +48,27 @@
 
 				<div id="inner-header" class="wrap cf">
 
-					<?php // to use a image just replace the bloginfo('name') with your img src and remove the surrounding <p> ?>
-					<p id="logo" class="h1" itemscope itemtype="http://schema.org/Organization"><a href="<?php echo home_url(); ?>" rel="nofollow"><?php bloginfo('name'); ?></a></p>
+					<?php // to use a image just replace the bloginfo( 'name' ) with your img src and remove the surrounding <p> ?>
+					<p id="logo" class="h1" itemscope itemtype="http://schema.org/Organization"><a href="<?php echo home_url(); ?>" rel="nofollow"><?php bloginfo( 'name' ); ?></a></p>
 
 					<?php // if you'd like to use the site description you can un-comment it below ?>
-					<?php // bloginfo('description'); ?>
-
+					<?php // bloginfo( 'description' ); ?>
 
 					<nav role="navigation" itemscope itemtype="http://schema.org/SiteNavigationElement">
-						<?php wp_nav_menu(array(
-    					         'container' => false,                           // remove nav container
-    					         'container_class' => 'menu cf',                 // class of container (should you choose to use it)
-    					         'menu' => __( 'The Main Menu', 'bonestheme' ),  // nav name
-    					         'menu_class' => 'nav top-nav cf',               // adding custom nav class
-    					         'theme_location' => 'main-nav',                 // where it's located in the theme
-    					         'before' => '',                                 // before the menu
-        			               'after' => '',                                  // after the menu
-        			               'link_before' => '',                            // before each link
-        			               'link_after' => '',                             // after each link
-        			               'depth' => 0,                                   // limit the depth of the nav
-    					         'fallback_cb' => ''                             // fallback function (if there is one)
-						)); ?>
+
+						<?php wp_nav_menu( array(
+							'container'       => false,                               // remove nav container
+							'container_class' => 'menu cf',                           // class of container (should you choose to use it)
+							'menu'            => __( 'The Main Menu', 'bonestheme' ), // nav name
+							'menu_class'      => 'nav top-nav cf',                    // adding custom nav class
+							'theme_location'  => 'main-nav',                          // where it's located in the theme
+							'before'          => '',                                  // before the menu
+							'after'           => '',                                  // after the menu
+							'link_before'     => '',                                  // before each link
+							'link_after'      => '',                                  // after each link
+							'depth'           => 0,                                   // limit the depth of the nav
+							'fallback_cb'     => '',                                  // fallback function (if there is one)
+						) ); ?>
 
 					</nav>
 

--- a/index.php
+++ b/index.php
@@ -20,7 +20,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									);
 
 								?></p>

--- a/index.php
+++ b/index.php
@@ -4,73 +4,87 @@
 
 				<div id="inner-content" class="wrap cf">
 
-						<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
+					<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
 
-							<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+						<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 
-							<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article">
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article">
 
-								<header class="article-header">
+							<header class="article-header">
 
-									<h1 class="h2 entry-title"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h1>
-									<p class="byline entry-meta vcard">
-                                        				<?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                       								/* the time the post was published */
-                       								'<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       								/* the author of the post */
-                       								'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    							); ?>
-									</p>
+								<h1 class="h2 entry-title"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h1>
+								
+								<p class="byline entry-meta vcard"><?php
 
-								</header>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									);
 
-								<section class="entry-content cf">
-									<?php the_content(); ?>
-								</section>
+								?></p>
 
-								<footer class="article-footer cf">
-									<p class="footer-comment-count">
-										<?php comments_number( __( '<span>No</span> Comments', 'bonestheme' ), __( '<span>One</span> Comment', 'bonestheme' ), __( '<span>%</span> Comments', 'bonestheme' ) );?>
-									</p>
+							</header>
 
+							<section class="entry-content cf">
+								
+								<?php the_content(); ?>
+							
+							</section>
 
-                 	<?php printf( '<p class="footer-category">' . __('filed under', 'bonestheme' ) . ': %1$s</p>' , get_the_category_list(', ') ); ?>
+							<footer class="article-footer cf">
+							
+								<p class="footer-comment-count"><?php
 
-                  <?php the_tags( '<p class="footer-tags tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+									comments_number( __( '<span>No</span> Comments', 'bonestheme' ), __( '<span>One</span> Comment', 'bonestheme' ), __( '<span>%</span> Comments', 'bonestheme' ) );
 
+								?></p>
 
-								</footer>
+								<?php printf( '<p class="footer-category">' . __('filed under', 'bonestheme' ) . ': %1$s</p>' , get_the_category_list( ', ' ) ); ?>
 
-							</article>
+								<?php the_tags( '<p class="footer-tags tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
 
-							<?php endwhile; ?>
+							</footer>
 
-									<?php bones_page_navi(); ?>
+						</article>
 
-							<?php else : ?>
+						<?php endwhile; ?>
 
-									<article id="post-not-found" class="hentry cf">
-											<header class="article-header">
-												<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
-										</header>
-											<section class="entry-content">
-												<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
-										</section>
-										<footer class="article-footer">
-												<p><?php _e( 'This is the error message in the index.php template.', 'bonestheme' ); ?></p>
-										</footer>
-									</article>
+						<?php bones_page_navi(); ?>
 
-							<?php endif; ?>
+						<?php else : ?>
 
+						<article id="post-not-found" class="hentry cf">
 
-						</main>
+							<header class="article-header">
+
+								<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
+
+							</header>
+
+							<section class="entry-content">
+
+								<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
+
+							</section>
+
+							<footer class="article-footer">
+
+								<p><?php _e( 'This is the error message in the index.php template.', 'bonestheme' ); ?></p>
+
+							</footer>
+
+						</article>
+
+						<?php endif; ?>
+
+					</main>
 
 					<?php get_sidebar(); ?>
 
 				</div>
 
 			</div>
-
 
 <?php get_footer(); ?>

--- a/library/bones.php
+++ b/library/bones.php
@@ -8,16 +8,16 @@ in the functions.php file.
 Developed by: Eddie Machado
 URL: http://themble.com/bones/
 
-  - head cleanup (remove rsd, uri links, junk css, ect)
-  - enqueueing scripts & styles
-  - theme support functions
-  - custom menu output & fallbacks
-  - related post function
-  - page-navi function
-  - removing <p> from around images
-  - customizing the post excerpt
-  - custom google+ integration
-  - adding custom fields to user profiles
+	- head cleanup (remove rsd, uri links, junk css, ect)
+	- enqueueing scripts & styles
+	- theme support functions
+	- custom menu output & fallbacks
+	- related post function
+	- page-navi function
+	- removing <p> from around images
+	- customizing the post excerpt
+	- custom google+ integration
+	- adding custom fields to user profiles
 
 */
 
@@ -56,31 +56,31 @@ function bones_head_cleanup() {
 // A better title
 // http://www.deluxeblogtips.com/2012/03/better-title-meta-tag.html
 function rw_title( $title, $sep, $seplocation ) {
-  global $page, $paged;
+	global $page, $paged;
 
-  // Don't affect in feeds.
-  if ( is_feed() ) return $title;
+	// Don't affect in feeds.
+	if ( is_feed() ) return $title;
 
-  // Add the blog's name
-  if ( 'right' == $seplocation ) {
-    $title .= get_bloginfo( 'name' );
-  } else {
-    $title = get_bloginfo( 'name' ) . $title;
-  }
+	// Add the blog's name
+	if ( 'right' == $seplocation ) {
+		$title .= get_bloginfo( 'name' );
+	} else {
+		$title = get_bloginfo( 'name' ) . $title;
+	}
 
-  // Add the blog description for the home/front page.
-  $site_description = get_bloginfo( 'description', 'display' );
+	// Add the blog description for the home/front page.
+	$site_description = get_bloginfo( 'description', 'display' );
 
-  if ( $site_description && ( is_home() || is_front_page() ) ) {
-    $title .= " {$sep} {$site_description}";
-  }
+	if ( $site_description && ( is_home() || is_front_page() ) ) {
+		$title .= " {$sep} {$site_description}";
+	}
 
-  // Add a page number if necessary:
-  if ( $paged >= 2 || $page >= 2 ) {
-    $title .= " {$sep} " . sprintf( __( 'Page %s', 'dbt' ), max( $paged, $page ) );
-  }
+	// Add a page number if necessary:
+	if ( $paged >= 2 || $page >= 2 ) {
+		$title .= " {$sep} " . sprintf( __( 'Page %s', 'dbt' ), max( $paged, $page ) );
+	}
 
-  return $title;
+	return $title;
 
 } // end better title
 
@@ -122,9 +122,9 @@ SCRIPTS & ENQUEUEING
 // loading modernizr and jquery, and reply script
 function bones_scripts_and_styles() {
 
-  global $wp_styles; // call global $wp_styles variable to add conditional wrapper around ie stylesheet the WordPress way
+	global $wp_styles; // call global $wp_styles variable to add conditional wrapper around ie stylesheet the WordPress way
 
-  if (!is_admin()) {
+	if (!is_admin()) {
 
 		// modernizr (without media query polyfill)
 		wp_register_script( 'bones-modernizr', get_stylesheet_directory_uri() . '/library/js/libs/modernizr.custom.min.js', array(), '2.5.3', false );
@@ -135,10 +135,10 @@ function bones_scripts_and_styles() {
 		// ie-only style sheet
 		wp_register_style( 'bones-ie-only', get_stylesheet_directory_uri() . '/library/css/ie.css', array(), '' );
 
-    // comment reply script for threaded comments
-    if ( is_singular() AND comments_open() AND (get_option('thread_comments') == 1)) {
-		  wp_enqueue_script( 'comment-reply' );
-    }
+		// comment reply script for threaded comments
+		if ( is_singular() AND comments_open() AND (get_option('thread_comments') == 1)) {
+			wp_enqueue_script( 'comment-reply' );
+		}
 
 		//adding scripts file in the footer
 		wp_register_script( 'bones-js', get_stylesheet_directory_uri() . '/library/js/scripts.js', array( 'jquery' ), '', true );
@@ -176,13 +176,13 @@ function bones_theme_support() {
 
 	// wp custom background (thx to @bransonwerner for update)
 	add_theme_support( 'custom-background',
-	    array(
-	    'default-image' => '',    // background image default
-	    'default-color' => '',    // background color default (dont add the #)
-	    'wp-head-callback' => '_custom_background_cb',
-	    'admin-head-callback' => '',
-	    'admin-preview-callback' => ''
-	    )
+			array(
+			'default-image' => '',    // background image default
+			'default-color' => '',    // background color default (dont add the #)
+			'wp-head-callback' => '_custom_background_cb',
+			'admin-head-callback' => '',
+			'admin-preview-callback' => ''
+			)
 	);
 
 	// rss thingy
@@ -255,23 +255,23 @@ PAGE NAVI
 
 // Numeric Page Navi (built into the theme by default)
 function bones_page_navi() {
-  global $wp_query;
-  $bignum = 999999999;
-  if ( $wp_query->max_num_pages <= 1 )
-    return;
-  echo '<nav class="pagination">';
-  echo paginate_links( array(
-    'base'         => str_replace( $bignum, '%#%', esc_url( get_pagenum_link($bignum) ) ),
-    'format'       => '',
-    'current'      => max( 1, get_query_var('paged') ),
-    'total'        => $wp_query->max_num_pages,
-    'prev_text'    => '&larr;',
-    'next_text'    => '&rarr;',
-    'type'         => 'list',
-    'end_size'     => 3,
-    'mid_size'     => 3
-  ) );
-  echo '</nav>';
+	global $wp_query;
+	$bignum = 999999999;
+	if ( $wp_query->max_num_pages <= 1 )
+		return;
+	echo '<nav class="pagination">';
+	echo paginate_links( array(
+		'base'         => str_replace( $bignum, '%#%', esc_url( get_pagenum_link($bignum) ) ),
+		'format'       => '',
+		'current'      => max( 1, get_query_var('paged') ),
+		'total'        => $wp_query->max_num_pages,
+		'prev_text'    => '&larr;',
+		'next_text'    => '&rarr;',
+		'type'         => 'list',
+		'end_size'     => 3,
+		'mid_size'     => 3
+	) );
+	echo '</nav>';
 } /* end page navi */
 
 /*********************

--- a/library/custom-post-type.php
+++ b/library/custom-post-type.php
@@ -66,64 +66,63 @@ function custom_post_example() {
 	
 }
 
-	// adding the function to the Wordpress init
-	add_action( 'init', 'custom_post_example');
-	
-	/*
-	for more information on taxonomies, go here:
-	http://codex.wordpress.org/Function_Reference/register_taxonomy
-	*/
-	
-	// now let's add custom categories (these act like categories)
-	register_taxonomy( 'custom_cat', 
-		array('custom_type'), /* if you change the name of register_post_type( 'custom_type', then you have to change this */
-		array('hierarchical' => true,     /* if this is true, it acts like categories */
-			'labels' => array(
-				'name' => __( 'Custom Categories', 'bonestheme' ), /* name of the custom taxonomy */
-				'singular_name' => __( 'Custom Category', 'bonestheme' ), /* single taxonomy name */
-				'search_items' =>  __( 'Search Custom Categories', 'bonestheme' ), /* search title for taxomony */
-				'all_items' => __( 'All Custom Categories', 'bonestheme' ), /* all title for taxonomies */
-				'parent_item' => __( 'Parent Custom Category', 'bonestheme' ), /* parent title for taxonomy */
-				'parent_item_colon' => __( 'Parent Custom Category:', 'bonestheme' ), /* parent taxonomy title */
-				'edit_item' => __( 'Edit Custom Category', 'bonestheme' ), /* edit custom taxonomy title */
-				'update_item' => __( 'Update Custom Category', 'bonestheme' ), /* update title for taxonomy */
-				'add_new_item' => __( 'Add New Custom Category', 'bonestheme' ), /* add new title for taxonomy */
-				'new_item_name' => __( 'New Custom Category Name', 'bonestheme' ) /* name title for taxonomy */
-			),
-			'show_admin_column' => true, 
-			'show_ui' => true,
-			'query_var' => true,
-			'rewrite' => array( 'slug' => 'custom-slug' ),
-		)
-	);
-	
-	// now let's add custom tags (these act like categories)
-	register_taxonomy( 'custom_tag', 
-		array('custom_type'), /* if you change the name of register_post_type( 'custom_type', then you have to change this */
-		array('hierarchical' => false,    /* if this is false, it acts like tags */
-			'labels' => array(
-				'name' => __( 'Custom Tags', 'bonestheme' ), /* name of the custom taxonomy */
-				'singular_name' => __( 'Custom Tag', 'bonestheme' ), /* single taxonomy name */
-				'search_items' =>  __( 'Search Custom Tags', 'bonestheme' ), /* search title for taxomony */
-				'all_items' => __( 'All Custom Tags', 'bonestheme' ), /* all title for taxonomies */
-				'parent_item' => __( 'Parent Custom Tag', 'bonestheme' ), /* parent title for taxonomy */
-				'parent_item_colon' => __( 'Parent Custom Tag:', 'bonestheme' ), /* parent taxonomy title */
-				'edit_item' => __( 'Edit Custom Tag', 'bonestheme' ), /* edit custom taxonomy title */
-				'update_item' => __( 'Update Custom Tag', 'bonestheme' ), /* update title for taxonomy */
-				'add_new_item' => __( 'Add New Custom Tag', 'bonestheme' ), /* add new title for taxonomy */
-				'new_item_name' => __( 'New Custom Tag Name', 'bonestheme' ) /* name title for taxonomy */
-			),
-			'show_admin_column' => true,
-			'show_ui' => true,
-			'query_var' => true,
-		)
-	);
-	
-	/*
-		looking for custom meta boxes?
-		check out this fantastic tool:
-		https://github.com/jaredatch/Custom-Metaboxes-and-Fields-for-WordPress
-	*/
-	
+// adding the function to the Wordpress init
+add_action( 'init', 'custom_post_example');
+
+/*
+for more information on taxonomies, go here:
+http://codex.wordpress.org/Function_Reference/register_taxonomy
+*/
+
+// now let's add custom categories (these act like categories)
+register_taxonomy( 'custom_cat', 
+	array('custom_type'), /* if you change the name of register_post_type( 'custom_type', then you have to change this */
+	array('hierarchical' => true,     /* if this is true, it acts like categories */
+		'labels' => array(
+			'name' => __( 'Custom Categories', 'bonestheme' ), /* name of the custom taxonomy */
+			'singular_name' => __( 'Custom Category', 'bonestheme' ), /* single taxonomy name */
+			'search_items' =>  __( 'Search Custom Categories', 'bonestheme' ), /* search title for taxomony */
+			'all_items' => __( 'All Custom Categories', 'bonestheme' ), /* all title for taxonomies */
+			'parent_item' => __( 'Parent Custom Category', 'bonestheme' ), /* parent title for taxonomy */
+			'parent_item_colon' => __( 'Parent Custom Category:', 'bonestheme' ), /* parent taxonomy title */
+			'edit_item' => __( 'Edit Custom Category', 'bonestheme' ), /* edit custom taxonomy title */
+			'update_item' => __( 'Update Custom Category', 'bonestheme' ), /* update title for taxonomy */
+			'add_new_item' => __( 'Add New Custom Category', 'bonestheme' ), /* add new title for taxonomy */
+			'new_item_name' => __( 'New Custom Category Name', 'bonestheme' ) /* name title for taxonomy */
+		),
+		'show_admin_column' => true, 
+		'show_ui' => true,
+		'query_var' => true,
+		'rewrite' => array( 'slug' => 'custom-slug' ),
+	)
+);
+
+// now let's add custom tags (these act like categories)
+register_taxonomy( 'custom_tag', 
+	array('custom_type'), /* if you change the name of register_post_type( 'custom_type', then you have to change this */
+	array('hierarchical' => false,    /* if this is false, it acts like tags */
+		'labels' => array(
+			'name' => __( 'Custom Tags', 'bonestheme' ), /* name of the custom taxonomy */
+			'singular_name' => __( 'Custom Tag', 'bonestheme' ), /* single taxonomy name */
+			'search_items' =>  __( 'Search Custom Tags', 'bonestheme' ), /* search title for taxomony */
+			'all_items' => __( 'All Custom Tags', 'bonestheme' ), /* all title for taxonomies */
+			'parent_item' => __( 'Parent Custom Tag', 'bonestheme' ), /* parent title for taxonomy */
+			'parent_item_colon' => __( 'Parent Custom Tag:', 'bonestheme' ), /* parent taxonomy title */
+			'edit_item' => __( 'Edit Custom Tag', 'bonestheme' ), /* edit custom taxonomy title */
+			'update_item' => __( 'Update Custom Tag', 'bonestheme' ), /* update title for taxonomy */
+			'add_new_item' => __( 'Add New Custom Tag', 'bonestheme' ), /* add new title for taxonomy */
+			'new_item_name' => __( 'New Custom Tag Name', 'bonestheme' ) /* name title for taxonomy */
+		),
+		'show_admin_column' => true,
+		'show_ui' => true,
+		'query_var' => true,
+	)
+);
+
+/*
+	looking for custom meta boxes?
+	check out this fantastic tool:
+	https://github.com/jaredatch/Custom-Metaboxes-and-Fields-for-WordPress
+*/
 
 ?>

--- a/page-custom.php
+++ b/page-custom.php
@@ -1,12 +1,15 @@
 <?php
 /*
- Template Name: Custom Page Example
- *
+Template Name: Custom Page Example
+*/
+
+/* 
+ * 
  * This is your custom page template. You can create as many of these as you need.
- * Simply name is "page-whatever.php" and in add the "Template Name" title at the
+ * Simply name it "page-whatever.php" and then add the "Template Name" title at the
  * top, the same way it is here.
  *
- * When you create your page, you can just select the template and viola, you have
+ * When you create your page, you can just select the template and voila, you have
  * a custom page template to call your very own. Your mother would be so proud.
  *
  * For more info: http://codex.wordpress.org/Page_Templates
@@ -19,83 +22,94 @@
 
 				<div id="inner-content" class="wrap cf">
 
-						<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
+					<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
 
-							<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+						<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 
-							<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
 
-								<header class="article-header">
+							<header class="article-header">
 
-									<h1 class="page-title"><?php the_title(); ?></h1>
+								<h1 class="page-title"><?php the_title(); ?></h1>
 
-									<p class="byline vcard">
-										<?php printf( __( 'Posted <time class="updated" datetime="%1$s" itemprop="datePublished">%2$s</time> by <span class="author">%3$s</span>', 'bonestheme' ), get_the_time('Y-m-j'), get_the_time(get_option('date_format')), get_the_author_link( get_the_author_meta( 'ID' ) )); ?>
-									</p>
+								<p class="byline vcard"><?php 
+									
+									printf( __( 'Posted <time class="updated" datetime="%1$s" itemprop="datePublished">%2$s</time> by <span class="author">%3$s</span>', 'bonestheme' ), get_the_time( 'Y-m-j' ), get_the_time( get_option( 'date_format' ) ), get_the_author_link( get_the_author_meta( 'ID' ) ) );
 
+								?></p>
 
-								</header>
+							</header>
 
-								<section class="entry-content cf" itemprop="articleBody">
-									<?php
-										// the content (pretty self explanatory huh)
-										the_content();
+							<section class="entry-content cf" itemprop="articleBody">
 
-										/*
-										 * Link Pages is used in case you have posts that are set to break into
-										 * multiple pages. You can remove this if you don't plan on doing that.
-										 *
-										 * Also, breaking content up into multiple pages is a horrible experience,
-										 * so don't do it. While there are SOME edge cases where this is useful, it's
-										 * mostly used for people to get more ad views. It's up to you but if you want
-										 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-										 *
-										 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-										 *
-										*/
-										wp_link_pages( array(
-											'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-											'after'       => '</div>',
-											'link_before' => '<span>',
-											'link_after'  => '</span>',
-										) );
-									?>
-								</section>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-								<footer class="article-footer">
+							</section>
 
-                  <?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+							<footer class="article-footer">
 
-								</footer>
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
 
-								<?php comments_template(); ?>
+							</footer>
 
-							</article>
+							<?php comments_template(); ?>
 
-							<?php endwhile; else : ?>
+						</article>
 
-									<article id="post-not-found" class="hentry cf">
-											<header class="article-header">
-												<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
-										</header>
-											<section class="entry-content">
-												<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
-										</section>
-										<footer class="article-footer">
-												<p><?php _e( 'This is the error message in the page-custom.php template.', 'bonestheme' ); ?></p>
-										</footer>
-									</article>
+						<?php endwhile; else : ?>
 
-							<?php endif; ?>
+						<article id="post-not-found" class="hentry cf">
 
-						</main>
+							<header class="article-header">
 
-						<?php get_sidebar(); ?>
+								<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
+
+							</header>
+
+							<section class="entry-content">
+
+								<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
+
+							</section>
+
+							<footer class="article-footer">
+
+								<p><?php _e( 'This is the error message in the page-custom.php template.', 'bonestheme' ); ?></p>
+
+							</footer>
+
+						</article>
+
+						<?php endif; ?>
+
+					</main>
+
+					<?php get_sidebar(); ?>
 
 				</div>
 
 			</div>
-
 
 <?php get_footer(); ?>

--- a/page.php
+++ b/page.php
@@ -4,75 +4,86 @@
 
 				<div id="inner-content" class="wrap cf">
 
-						<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
+					<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
 
-							<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+						<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 
-							<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
 
-								<header class="article-header">
+							<header class="article-header">
 
-									<h1 class="page-title" itemprop="headline"><?php the_title(); ?></h1>
+								<h1 class="page-title" itemprop="headline"><?php the_title(); ?></h1>
 
-									<p class="byline vcard">
-										<?php printf( __( 'Posted <time class="updated" datetime="%1$s" itemprop="datePublished">%2$s</time> by <span class="author">%3$s</span>', 'bonestheme' ), get_the_time('Y-m-j'), get_the_time(get_option('date_format')), get_the_author_link( get_the_author_meta( 'ID' ) )); ?>
-									</p>
+								<p class="byline vcard"><?php
 
-								</header> <?php // end article header ?>
+									printf( __( 'Posted <time class="updated" datetime="%1$s" itemprop="datePublished">%2$s</time> by <span class="author">%3$s</span>', 'bonestheme' ), get_the_time( 'Y-m-j' ), get_the_time( get_option( 'date_format' ) ), get_the_author_link( get_the_author_meta( 'ID' ) ) );
 
-								<section class="entry-content cf" itemprop="articleBody">
-									<?php
-										// the content (pretty self explanatory huh)
-										the_content();
+								?></p>
 
-										/*
-										 * Link Pages is used in case you have posts that are set to break into
-										 * multiple pages. You can remove this if you don't plan on doing that.
-										 *
-										 * Also, breaking content up into multiple pages is a horrible experience,
-										 * so don't do it. While there are SOME edge cases where this is useful, it's
-										 * mostly used for people to get more ad views. It's up to you but if you want
-										 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-										 *
-										 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-										 *
-										*/
-										wp_link_pages( array(
-											'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-											'after'       => '</div>',
-											'link_before' => '<span>',
-											'link_after'  => '</span>',
-										) );
-									?>
-								</section> <?php // end article section ?>
+							</header>
 
-								<footer class="article-footer cf">
+							<section class="entry-content cf" itemprop="articleBody">
 
-								</footer>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-								<?php comments_template(); ?>
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-							</article>
+							</section>
 
-							<?php endwhile; else : ?>
+							<footer class="article-footer cf"></footer>
 
-									<article id="post-not-found" class="hentry cf">
-										<header class="article-header">
-											<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
-										</header>
-										<section class="entry-content">
-											<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
-										</section>
-										<footer class="article-footer">
-												<p><?php _e( 'This is the error message in the page.php template.', 'bonestheme' ); ?></p>
-										</footer>
-									</article>
+							<?php comments_template(); ?>
 
-							<?php endif; ?>
+						</article>
 
-						</main>
+						<?php endwhile; else : ?>
 
-						<?php get_sidebar(); ?>
+						<article id="post-not-found" class="hentry cf">
+
+							<header class="article-header">
+
+								<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
+
+							</header>
+
+							<section class="entry-content">
+
+								<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
+
+							</section>
+
+							<footer class="article-footer">
+
+								<p><?php _e( 'This is the error message in the page.php template.', 'bonestheme' ); ?></p>
+
+							</footer>
+
+						</article>
+
+						<?php endif; ?>
+
+					</main>
+
+					<?php get_sidebar(); ?>
 
 				</div>
 

--- a/post-formats/format-aside.php
+++ b/post-formats/format-aside.php
@@ -1,53 +1,56 @@
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemprop="blogPost" itemtype="http://schema.org/BlogPosting">
 
+							<header class="article-header entry-header">
 
-              <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article" itemscope itemprop="blogPost" itemtype="http://schema.org/BlogPosting">
+								<h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
 
-                <header class="article-header entry-header">
+								<p class="byline entry-meta vcard"><?php
 
-                  <h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									); 
 
-                  <p class="byline entry-meta vcard">
-                    <?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                       /* the time the post was published */
-                       '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       /* the author of the post */
-                       '<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    ); ?>
-                  </p>
+								?></p>
 
-                </header> <?php // end article header ?>
+							</header>
 
-                <section class="entry-content cf" itemprop="articleBody">
-                  <?php
-                    // the content (pretty self explanatory huh)
-                    the_content();
+							<section class="entry-content cf" itemprop="articleBody">
 
-                    /*
-                     * Link Pages is used in case you have posts that are set to break into
-                     * multiple pages. You can remove this if you don't plan on doing that.
-                     *
-                     * Also, breaking content up into multiple pages is a horrible experience,
-                     * so don't do it. While there are SOME edge cases where this is useful, it's
-                     * mostly used for people to get more ad views. It's up to you but if you want
-                     * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-                     *
-                     * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-                     *
-                    */
-                    wp_link_pages( array(
-                      'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-                      'after'       => '</div>',
-                      'link_before' => '<span>',
-                      'link_after'  => '</span>',
-                    ) );
-                  ?>
-                </section> <?php // end article section ?>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-                <footer class="article-footer entry-footer">
-                  <?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-                </footer> <?php // end article footer ?>
+							</section>
 
-                <?php comments_template(); ?>
+							<footer class="article-footer entry-footer">
 
-              </article> <?php // end article ?>
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+
+							</footer>
+
+							<?php comments_template(); ?>
+
+						</article>

--- a/post-formats/format-aside.php
+++ b/post-formats/format-aside.php
@@ -10,7 +10,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									); 
 
 								?></p>

--- a/post-formats/format-audio.php
+++ b/post-formats/format-audio.php
@@ -10,7 +10,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									); 
 
 								?></p>

--- a/post-formats/format-audio.php
+++ b/post-formats/format-audio.php
@@ -1,53 +1,56 @@
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/AudioObject">
 
+							<header class="article-header">
 
-              <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article" itemscope itemtype="http://schema.org/AudioObject">
+								<h1 class="entry-title single-title" itemprop="name"><?php the_title(); ?></h1>
 
-                <header class="article-header">
+								<p class="byline entry-meta vcard"><?php
 
-                  <h1 class="entry-title single-title" itemprop="name"><?php the_title(); ?></h1>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									); 
 
-                  <p class="byline entry-meta vcard">
-                    <?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                       /* the time the post was published */
-                       '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       /* the author of the post */
-                       '<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    ); ?>
-                  </p>
+								?></p>
 
-                </header> <?php // end article header ?>
+							</header>
 
-                <section class="entry-content cf" itemprop="description">
-                  <?php
-                    // the content (pretty self explanatory huh)
-                    the_content();
+							<section class="entry-content cf" itemprop="description">
 
-                    /*
-                     * Link Pages is used in case you have posts that are set to break into
-                     * multiple pages. You can remove this if you don't plan on doing that.
-                     *
-                     * Also, breaking content up into multiple pages is a horrible experience,
-                     * so don't do it. While there are SOME edge cases where this is useful, it's
-                     * mostly used for people to get more ad views. It's up to you but if you want
-                     * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-                     *
-                     * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-                     *
-                    */
-                    wp_link_pages( array(
-                      'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-                      'after'       => '</div>',
-                      'link_before' => '<span>',
-                      'link_after'  => '</span>',
-                    ) );
-                  ?>
-                </section> <?php // end article section ?>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-                <footer class="article-footer">
-                  <?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-                </footer> <?php // end article footer ?>
+							</section>
 
-                <?php comments_template(); ?>
+							<footer class="article-footer">
 
-              </article> <?php // end article ?>
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+
+							</footer>
+
+							<?php comments_template(); ?>
+
+						</article>

--- a/post-formats/format-chat.php
+++ b/post-formats/format-chat.php
@@ -10,7 +10,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									);
 
 								?></p>

--- a/post-formats/format-chat.php
+++ b/post-formats/format-chat.php
@@ -1,53 +1,56 @@
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
 
+							<header class="article-header">
 
-              <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
+								<h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
 
-                <header class="article-header">
+								<p class="byline vcard"><?php
 
-                  <h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									);
 
-                  <p class="byline vcard">
-                    <?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                       /* the time the post was published */
-                       '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       /* the author of the post */
-                       '<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    ); ?>
-                  </p>
+								?></p>
 
-                </header> <?php // end article header ?>
+							</header>
 
-                <section class="entry-content cf" itemprop="articleBody">
-                  <?php
-                    // the content (pretty self explanatory huh)
-                    the_content();
+							<section class="entry-content cf" itemprop="articleBody">
 
-                    /*
-                     * Link Pages is used in case you have posts that are set to break into
-                     * multiple pages. You can remove this if you don't plan on doing that.
-                     *
-                     * Also, breaking content up into multiple pages is a horrible experience,
-                     * so don't do it. While there are SOME edge cases where this is useful, it's
-                     * mostly used for people to get more ad views. It's up to you but if you want
-                     * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-                     *
-                     * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-                     *
-                    */
-                    wp_link_pages( array(
-                      'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-                      'after'       => '</div>',
-                      'link_before' => '<span>',
-                      'link_after'  => '</span>',
-                    ) );
-                  ?>
-                </section> <?php // end article section ?>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-                <footer class="article-footer">
-                  <?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-                </footer> <?php // end article footer ?>
+							</section>
 
-                <?php comments_template(); ?>
+							<footer class="article-footer">
 
-              </article> <?php // end article ?>
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+
+							</footer>
+
+							<?php comments_template(); ?>
+
+						</article>

--- a/post-formats/format-gallery.php
+++ b/post-formats/format-gallery.php
@@ -10,7 +10,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									); 
 
 								?></p>

--- a/post-formats/format-gallery.php
+++ b/post-formats/format-gallery.php
@@ -1,53 +1,56 @@
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
 
+							<header class="article-header">
 
-              <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
+								<h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
 
-                <header class="article-header">
+								<p class="byline vcard"><?php
 
-                  <h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									); 
 
-                  <p class="byline vcard">
-                    <?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                       /* the time the post was published */
-                       '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       /* the author of the post */
-                       '<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    ); ?>
-                  </p>
+								?></p>
 
-                </header> <?php // end article header ?>
+							</header>
 
-                <section class="entry-content cf" itemprop="articleBody">
-                  <?php
-                    // the content (pretty self explanatory huh)
-                    the_content();
+							<section class="entry-content cf" itemprop="articleBody">
 
-                    /*
-                     * Link Pages is used in case you have posts that are set to break into
-                     * multiple pages. You can remove this if you don't plan on doing that.
-                     *
-                     * Also, breaking content up into multiple pages is a horrible experience,
-                     * so don't do it. While there are SOME edge cases where this is useful, it's
-                     * mostly used for people to get more ad views. It's up to you but if you want
-                     * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-                     *
-                     * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-                     *
-                    */
-                    wp_link_pages( array(
-                      'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-                      'after'       => '</div>',
-                      'link_before' => '<span>',
-                      'link_after'  => '</span>',
-                    ) );
-                  ?>
-                </section> <?php // end article section ?>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-                <footer class="article-footer">
-                  <?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-                </footer> <?php // end article footer ?>
+							</section>
 
-                <?php comments_template(); ?>
+							<footer class="article-footer">
 
-              </article> <?php // end article ?>
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+
+							</footer>
+
+							<?php comments_template(); ?>
+
+						</article>

--- a/post-formats/format-image.php
+++ b/post-formats/format-image.php
@@ -10,7 +10,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									); 
 
 								?></p>

--- a/post-formats/format-image.php
+++ b/post-formats/format-image.php
@@ -1,53 +1,56 @@
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
 
+							<header class="article-header">
 
-              <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
+								<h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
 
-                <header class="article-header">
+								<p class="byline vcard"><?php
 
-                  <h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									); 
 
-                  <p class="byline vcard">
-                    <?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                       /* the time the post was published */
-                       '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       /* the author of the post */
-                       '<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    ); ?>
-                  </p>
+								?></p>
 
-                </header> <?php // end article header ?>
+							</header>
 
-                <section class="entry-content cf" itemprop="articleBody">
-                  <?php
-                    // the content (pretty self explanatory huh)
-                    the_content();
+							<section class="entry-content cf" itemprop="articleBody">
 
-                    /*
-                     * Link Pages is used in case you have posts that are set to break into
-                     * multiple pages. You can remove this if you don't plan on doing that.
-                     *
-                     * Also, breaking content up into multiple pages is a horrible experience,
-                     * so don't do it. While there are SOME edge cases where this is useful, it's
-                     * mostly used for people to get more ad views. It's up to you but if you want
-                     * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-                     *
-                     * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-                     *
-                    */
-                    wp_link_pages( array(
-                      'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-                      'after'       => '</div>',
-                      'link_before' => '<span>',
-                      'link_after'  => '</span>',
-                    ) );
-                  ?>
-                </section> <?php // end article section ?>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-                <footer class="article-footer">
-                  <?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-                </footer> <?php // end article footer ?>
+							</section>
 
-                <?php comments_template(); ?>
+							<footer class="article-footer">
 
-              </article> <?php // end article ?>
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+
+							</footer>
+
+							<?php comments_template(); ?>
+
+						</article>

--- a/post-formats/format-link.php
+++ b/post-formats/format-link.php
@@ -1,56 +1,58 @@
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
 
+							<header class="article-header">
 
-              <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
+								<h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
 
-                <header class="article-header">
+								<p class="byline vcard"><?php
 
-                  <h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									);
 
-                  <p class="byline vcard">
-                    <?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                       /* the time the post was published */
-                       '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       /* the author of the post */
-                       '<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    ); ?>
-                  </p>
+								?></p>
 
-                </header> <?php // end article header ?>
+							</header>
 
-                <section class="entry-content cf" itemprop="articleBody">
-                  <?php
-                    // the content (pretty self explanatory huh)
-                    the_content();
+							<section class="entry-content cf" itemprop="articleBody">
 
-                    /*
-                     * Link Pages is used in case you have posts that are set to break into
-                     * multiple pages. You can remove this if you don't plan on doing that.
-                     *
-                     * Also, breaking content up into multiple pages is a horrible experience,
-                     * so don't do it. While there are SOME edge cases where this is useful, it's
-                     * mostly used for people to get more ad views. It's up to you but if you want
-                     * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-                     *
-                     * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-                     *
-                    */
-                    wp_link_pages( array(
-                      'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-                      'after'       => '</div>',
-                      'link_before' => '<span>',
-                      'link_after'  => '</span>',
-                    ) );
-                  ?>
-                </section> <?php // end article section ?>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-                <footer class="article-footer">
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-                  <?php printf( __( 'Filed under: %1$s', 'bonestheme' ), get_the_category_list(', ') ); ?>
+							</section>
 
-                  <?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+							<footer class="article-footer">
 
-                </footer> <?php // end article footer ?>
+								<?php printf( __( 'Filed under: %1$s', 'bonestheme' ), get_the_category_list( ', ' ) ); ?>
 
-                <?php comments_template(); ?>
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
 
-              </article> <?php // end article ?>
+							</footer>
+
+							<?php comments_template(); ?>
+
+						</article>

--- a/post-formats/format-link.php
+++ b/post-formats/format-link.php
@@ -10,7 +10,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									);
 
 								?></p>

--- a/post-formats/format-quote.php
+++ b/post-formats/format-quote.php
@@ -1,56 +1,58 @@
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
 
+							<header class="article-header">
 
-              <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
+								<h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
 
-                <header class="article-header">
+								<p class="byline vcard"><?php
 
-                  <h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									);
 
-                  <p class="byline vcard">
-                    <?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                       /* the time the post was published */
-                       '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       /* the author of the post */
-                       '<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    ); ?>
-                  </p>
+								?></p>
 
-                </header> <?php // end article header ?>
+							</header>
 
-                <section class="entry-content cf" itemprop="articleBody">
-                  <?php
-                    // the content (pretty self explanatory huh)
-                    the_content();
+							<section class="entry-content cf" itemprop="articleBody">
 
-                    /*
-                     * Link Pages is used in case you have posts that are set to break into
-                     * multiple pages. You can remove this if you don't plan on doing that.
-                     *
-                     * Also, breaking content up into multiple pages is a horrible experience,
-                     * so don't do it. While there are SOME edge cases where this is useful, it's
-                     * mostly used for people to get more ad views. It's up to you but if you want
-                     * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-                     *
-                     * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-                     *
-                    */
-                    wp_link_pages( array(
-                      'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-                      'after'       => '</div>',
-                      'link_before' => '<span>',
-                      'link_after'  => '</span>',
-                    ) );
-                  ?>
-                </section> <?php // end article section ?>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-                <footer class="article-footer">
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-                  <?php printf( __( 'Filed under: %1$s', 'bonestheme' ), get_the_category_list(', ') ); ?>
+							</section>
 
-                  <?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+							<footer class="article-footer">
 
-                </footer> <?php // end article footer ?>
+								<?php printf( __( 'Filed under: %1$s', 'bonestheme' ), get_the_category_list( ', ' ) ); ?>
 
-                <?php comments_template(); ?>
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
 
-              </article> <?php // end article ?>
+							</footer>
+
+							<?php comments_template(); ?>
+
+						</article>

--- a/post-formats/format-quote.php
+++ b/post-formats/format-quote.php
@@ -10,7 +10,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									);
 
 								?></p>

--- a/post-formats/format-status.php
+++ b/post-formats/format-status.php
@@ -10,7 +10,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									);
 
 								?></p>

--- a/post-formats/format-status.php
+++ b/post-formats/format-status.php
@@ -1,53 +1,56 @@
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
 
+							<header class="article-header">
 
-              <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article" itemscope itemtype="http://schema.org/BlogPosting">
+								<h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
 
-                <header class="article-header">
+								<p class="byline vcard"><?php
 
-                  <h1 class="entry-title single-title" itemprop="headline"><?php the_title(); ?></h1>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									);
 
-                  <p class="byline vcard">
-                    <?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                       /* the time the post was published */
-                       '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       /* the author of the post */
-                       '<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    ); ?>
-                  </p>
+								?></p>
 
-                </header> <?php // end article header ?>
+							</header>
 
-                <section class="entry-content cf" itemprop="articleBody">
-                  <?php
-                    // the content (pretty self explanatory huh)
-                    the_content();
+							<section class="entry-content cf" itemprop="articleBody">
 
-                    /*
-                     * Link Pages is used in case you have posts that are set to break into
-                     * multiple pages. You can remove this if you don't plan on doing that.
-                     *
-                     * Also, breaking content up into multiple pages is a horrible experience,
-                     * so don't do it. While there are SOME edge cases where this is useful, it's
-                     * mostly used for people to get more ad views. It's up to you but if you want
-                     * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-                     *
-                     * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-                     *
-                    */
-                    wp_link_pages( array(
-                      'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-                      'after'       => '</div>',
-                      'link_before' => '<span>',
-                      'link_after'  => '</span>',
-                    ) );
-                  ?>
-                </section> <?php // end article section ?>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-                <footer class="article-footer">
-                  <?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-                </footer> <?php // end article footer ?>
+							</section>
 
-                <?php comments_template(); ?>
+							<footer class="article-footer">
 
-              </article> <?php // end article ?>
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+
+							</footer>
+
+							<?php comments_template(); ?>
+
+						</article>

--- a/post-formats/format-video.php
+++ b/post-formats/format-video.php
@@ -1,53 +1,56 @@
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemtype="http://schema.org/VideoObject">
 
+							<header class="article-header entry-header">
 
-              <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article" itemscope itemtype="http://schema.org/VideoObject">
+								<h1 class="entry-title single-title" itemprop="name"><?php the_title(); ?></h1>
 
-                <header class="article-header entry-header">
+								<p class="byline entry-meta vcard"><?php
 
-                  <h1 class="entry-title single-title" itemprop="name"><?php the_title(); ?></h1>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									);
 
-                  <p class="byline entry-meta vcard">
-                    <?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                       /* the time the post was published */
-                       '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       /* the author of the post */
-                       '<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    ); ?>
-                  </p>
+								?></p>
 
-                </header> <?php // end article header ?>
+							</header>
 
-                <section class="entry-content cf" itemprop="description">
-                  <?php
-                    // the content (pretty self explanatory huh)
-                    the_content();
+							<section class="entry-content cf" itemprop="description">
 
-                    /*
-                     * Link Pages is used in case you have posts that are set to break into
-                     * multiple pages. You can remove this if you don't plan on doing that.
-                     *
-                     * Also, breaking content up into multiple pages is a horrible experience,
-                     * so don't do it. While there are SOME edge cases where this is useful, it's
-                     * mostly used for people to get more ad views. It's up to you but if you want
-                     * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-                     *
-                     * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-                     *
-                    */
-                    wp_link_pages( array(
-                      'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-                      'after'       => '</div>',
-                      'link_before' => '<span>',
-                      'link_after'  => '</span>',
-                    ) );
-                  ?>
-                </section> <?php // end article section ?>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-                <footer class="article-footer">
-                  <?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-                </footer> <?php // end article footer ?>
+							</section>
 
-                <?php comments_template(); ?>
+							<footer class="article-footer">
 
-              </article> <?php // end article ?>
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+
+							</footer>
+
+							<?php comments_template(); ?>
+
+						</article>

--- a/post-formats/format-video.php
+++ b/post-formats/format-video.php
@@ -10,7 +10,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									);
 
 								?></p>

--- a/post-formats/format.php
+++ b/post-formats/format.php
@@ -21,7 +21,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									);
 
 								?></p>

--- a/post-formats/format.php
+++ b/post-formats/format.php
@@ -1,72 +1,69 @@
+						<?php
+							/*
+							 * This is the default post format.
+							 *
+							 * So basically this is a regular post. If you don't want to use post formats,
+							 * you can just copy this stuff in here and replace the get_template_part function call in
+							 * single.php. Then you are free to delete the post-formats folder.
+							 *
+							 * The other formats are SUPER basic so you can style them as you like.
+							*/
+						?>
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article" itemscope itemprop="blogPost" itemtype="http://schema.org/BlogPosting">
 
-              <?php
-                /*
-                 * This is the default post format.
-                 *
-                 * So basically this is a regular post. if you don't want to use post formats,
-                 * you can just copy ths stuff in here and replace the post format thing in
-                 * single.php.
-                 *
-                 * The other formats are SUPER basic so you can style them as you like.
-                 *
-                 * Again, If you want to remove post formats, just delete the post-formats
-                 * folder and replace the function below with the contents of the "format.php" file.
-                */
-              ?>
+							<header class="article-header entry-header">
 
-              <article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article" itemscope itemprop="blogPost" itemtype="http://schema.org/BlogPosting">
+								<h1 class="entry-title single-title" itemprop="headline" rel="bookmark"><?php the_title(); ?></h1>
 
-                <header class="article-header entry-header">
+								<p class="byline entry-meta vcard"><?php
 
-                  <h1 class="entry-title single-title" itemprop="headline" rel="bookmark"><?php the_title(); ?></h1>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									);
 
-                  <p class="byline entry-meta vcard">
+								?></p>
 
-                    <?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                       /* the time the post was published */
-                       '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                       /* the author of the post */
-                       '<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    ); ?>
+							</header>
 
-                  </p>
+							<section class="entry-content cf" itemprop="articleBody">
 
-                </header> <?php // end article header ?>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-                <section class="entry-content cf" itemprop="articleBody">
-                  <?php
-                    // the content (pretty self explanatory huh)
-                    the_content();
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-                    /*
-                     * Link Pages is used in case you have posts that are set to break into
-                     * multiple pages. You can remove this if you don't plan on doing that.
-                     *
-                     * Also, breaking content up into multiple pages is a horrible experience,
-                     * so don't do it. While there are SOME edge cases where this is useful, it's
-                     * mostly used for people to get more ad views. It's up to you but if you want
-                     * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-                     *
-                     * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-                     *
-                    */
-                    wp_link_pages( array(
-                      'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-                      'after'       => '</div>',
-                      'link_before' => '<span>',
-                      'link_after'  => '</span>',
-                    ) );
-                  ?>
-                </section> <?php // end article section ?>
+							</section>
 
-                <footer class="article-footer">
+							<footer class="article-footer">
 
-                  <?php printf( __( 'Filed under: %1$s', 'bonestheme' ), get_the_category_list(', ') ); ?>
+								<?php printf( __( 'Filed under: %1$s', 'bonestheme' ), get_the_category_list( ', ' ) ); ?>
 
-                  <?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
 
-                </footer> <?php // end article footer ?>
+							</footer>
 
-                <?php comments_template(); ?>
+							<?php comments_template(); ?>
 
-              </article> <?php // end article ?>
+						</article>

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A Lightweight Wordpress Development Theme
 Bones is designed to make the life of developers easier. It's built
 using HTML5 & has a strong semantic foundation.
 It's constantly growing so be sure to check back often if you are a
-frequent user. I'm always open to contribution. :)
+frequent user. I'm always open to contributions. :)
 
 Designed by Eddie Machado
 http://themble.com/bones
@@ -14,11 +14,11 @@ License URI: http://sam.zoy.org/wtfpl/
 Are You Serious? Yes.
 
 #### Special Thanks to:
-Paul Irish & the HTML5 Boilerplate
-Yoast for some WP functions & optimization ideas
-Andrew Rogers for code optimization
-David Dellanave for speed & code optimization
-and several other developers. :)
+* Paul Irish & the HTML5 Boilerplate
+* Yoast for some WP functions & optimization ideas
+* Andrew Rogers for code optimization
+* David Dellanave for speed & code optimization
+* and several other developers. :)
 
 #### Submit Bugs & or Fixes:
 https://github.com/eddiemachado/bones/issues

--- a/search.php
+++ b/search.php
@@ -5,69 +5,83 @@
 				<div id="inner-content" class="wrap cf">
 
 					<main id="main" class="m-all t-2of3 d-5of7 cf" role="main">
-						<h1 class="archive-title"><span><?php _e( 'Search Results for:', 'bonestheme' ); ?></span> <?php echo esc_attr(get_search_query()); ?></h1>
 
-						<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+						<h1 class="archive-title"><span><?php _e( 'Search Results for:', 'bonestheme' ); ?></span> <?php echo esc_attr( get_search_query() ); ?></h1>
 
-							<article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article">
+						<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 
-								<header class="entry-header article-header">
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article">
 
-									<h3 class="search-title entry-title"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h3>
+							<header class="entry-header article-header">
 
-                  						<p class="byline entry-meta vcard">
-                    							<?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
-                   							    /* the time the post was published */
-                   							    '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
-                      							    /* the author of the post */
-                       							    '<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
-                    							); ?>
-                  						</p>
+								<h3 class="search-title entry-title"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h3>
 
-								</header>
+								<p class="byline entry-meta vcard"><?php
 
-								<section class="entry-content">
-										<?php the_excerpt( '<span class="read-more">' . __( 'Read more &raquo;', 'bonestheme' ) . '</span>' ); ?>
+									printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										/* the time the post was published */
+										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
+										/* the author of the post */
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+									); 
 
-								</section>
+								?></p>
 
-								<footer class="article-footer">
+							</header>
 
-									<?php if(get_the_category_list(', ') != ''): ?>
-                  					<?php printf( __( 'Filed under: %1$s', 'bonestheme' ), get_the_category_list(', ') ); ?>
-                  					<?php endif; ?>
+							<section class="entry-content">
 
-                 					<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+								<?php the_excerpt( '<span class="read-more">' . __( 'Read more &raquo;', 'bonestheme' ) . '</span>' ); ?>
 
-								</footer> <!-- end article footer -->
+							</section>
 
-							</article>
+							<footer class="article-footer">
+
+								<?php if(get_the_category_list( ', ' ) != ''): ?>
+									<?php printf( __( 'Filed under: %1$s', 'bonestheme' ), get_the_category_list( ', ' ) ); ?>
+								<?php endif; ?>
+
+								<?php the_tags( '<p class="tags"><span class="tags-title">' . __( 'Tags:', 'bonestheme' ) . '</span> ', ', ', '</p>' ); ?>
+
+							</footer>
+
+						</article>
 
 						<?php endwhile; ?>
 
-								<?php bones_page_navi(); ?>
+						<?php bones_page_navi(); ?>
 
-							<?php else : ?>
+						<?php else : ?>
 
-									<article id="post-not-found" class="hentry cf">
-										<header class="article-header">
-											<h1><?php _e( 'Sorry, No Results.', 'bonestheme' ); ?></h1>
-										</header>
-										<section class="entry-content">
-											<p><?php _e( 'Try your search again.', 'bonestheme' ); ?></p>
-										</section>
-										<footer class="article-footer">
-												<p><?php _e( 'This is the error message in the search.php template.', 'bonestheme' ); ?></p>
-										</footer>
-									</article>
+						<article id="post-not-found" class="hentry cf">
 
-							<?php endif; ?>
+							<header class="article-header">
 
-						</main>
+								<h1><?php _e( 'Sorry, No Results.', 'bonestheme' ); ?></h1>
 
-							<?php get_sidebar(); ?>
+							</header>
 
-					</div>
+							<section class="entry-content">
+
+								<p><?php _e( 'Try your search again.', 'bonestheme' ); ?></p>
+
+							</section>
+
+							<footer class="article-footer">
+
+								<p><?php _e( 'This is the error message in the search.php template.', 'bonestheme' ); ?></p>
+
+							</footer>
+
+						</article>
+
+						<?php endif; ?>
+
+					</main>
+
+					<?php get_sidebar(); ?>
+
+				</div>
 
 			</div>
 

--- a/search.php
+++ b/search.php
@@ -22,7 +22,7 @@
 										/* the time the post was published */
 										'<time class="updated entry-time" datetime="' . get_the_time( 'Y-m-d' ) . '" itemprop="datePublished">' . get_the_time( get_option( 'date_format' ) ) . '</time>',
 										/* the author of the post */
-										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemptype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
+										'<span class="by">by</span> <span class="entry-author author" itemprop="author" itemscope itemtype="http://schema.org/Person">' . get_the_author_link( get_the_author_meta( 'ID' ) ) . '</span>'
 									); 
 
 								?></p>

--- a/searchform.php
+++ b/searchform.php
@@ -1,8 +1,13 @@
 <form role="search" method="get" id="searchform" class="searchform" action="<?php echo home_url( '/' ); ?>">
-    <div>
-        <label for="s" class="screen-reader-text"><?php _e('Search for:','bonestheme'); ?></label>
-        <input type="search" id="s" name="s" value="" />
 
-        <button type="submit" id="searchsubmit" ><?php _e('Search','bonestheme'); ?></button>
-    </div>
+	<div>
+
+		<label for="s" class="screen-reader-text"><?php _e( 'Search for:','bonestheme' ); ?></label>
+
+		<input type="search" id="s" name="s" value="" />
+
+		<button type="submit" id="searchsubmit" ><?php _e( 'Search','bonestheme' ); ?></button>
+
+	</div>
+
 </form>

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,21 +1,18 @@
-				<div id="sidebar1" class="sidebar m-all t-1of3 d-2of7 last-col cf" role="complementary">
+					<div id="sidebar1" class="sidebar m-all t-1of3 d-2of7 last-col cf" role="complementary">
 
-					<?php if ( is_active_sidebar( 'sidebar1' ) ) : ?>
+						<?php if ( is_active_sidebar( 'sidebar1' ) ) : ?>
 
 						<?php dynamic_sidebar( 'sidebar1' ); ?>
 
-					<?php else : ?>
+						<?php else : ?>
 
-						<?php
-							/*
-							 * This content shows up if there are no widgets defined in the backend.
-							*/
-						?>
-
+						<?php // This content shows up if there are no widgets defined in the backend. ?>
 						<div class="no-widgets">
+
 							<p><?php _e( 'This is a widget ready area. Add some and they will appear here.', 'bonestheme' );  ?></p>
+
 						</div>
 
-					<?php endif; ?>
+						<?php endif; ?>
 
-				</div>
+					</div>

--- a/single-custom_type.php
+++ b/single-custom_type.php
@@ -5,8 +5,8 @@
  * This is the custom post type post template. If you edit the post type name, you've got
  * to change the name of this template to reflect that name change.
  *
- * For Example, if your custom post type is "register_post_type( 'bookmarks')",
- * then your single template should be single-bookmarks.php
+ * For example, if your custom post type is "register_post_type( 'bookmarks' )",
+ * then your single template should be named single-bookmarks.php
  *
  * Be aware that you should rename 'custom_cat' and 'custom_tag' to the appropiate custom
  * category and taxonomy slugs, or this template will not finish to load properly.
@@ -21,77 +21,93 @@
 
 				<div id="inner-content" class="wrap cf">
 
-						<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
+					<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
 
-							<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+						<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 
-							<article id="post-<?php the_ID(); ?>" <?php post_class('cf'); ?> role="article">
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article">
 
-								<header class="article-header">
+							<header class="article-header">
 
-									<h1 class="single-title custom-post-type-title"><?php the_title(); ?></h1>
-									<p class="byline vcard"><?php
-										printf( __( 'Posted <time class="updated" datetime="%1$s" itemprop="datePublished">%2$s</time> by <span class="author">%3$s</span> <span class="amp">&</span> filed under %4$s.', 'bonestheme' ), get_the_time( 'Y-m-j' ), get_the_time(get_option('date_format')), get_the_author_link( get_the_author_meta( 'ID' ) ), get_the_term_list( $post->ID, 'custom_cat', ' ', ', ', '' ) );
-									?></p>
+								<h1 class="single-title custom-post-type-title"><?php the_title(); ?></h1>
 
-								</header>
+								<p class="byline vcard"><?php
 
-								<section class="entry-content cf">
-									<?php
-										// the content (pretty self explanatory huh)
-										the_content();
+									printf( __( 'Posted <time class="updated" datetime="%1$s" itemprop="datePublished">%2$s</time> by <span class="author">%3$s</span> <span class="amp">&</span> filed under %4$s.', 'bonestheme' ), get_the_time( 'Y-m-j' ), get_the_time( get_option( 'date_format' ) ), get_the_author_link( get_the_author_meta( 'ID' ) ), get_the_term_list( $post->ID, 'custom_cat', ' ', ', ', '' ) );
 
-										/*
-										 * Link Pages is used in case you have posts that are set to break into
-										 * multiple pages. You can remove this if you don't plan on doing that.
-										 *
-										 * Also, breaking content up into multiple pages is a horrible experience,
-										 * so don't do it. While there are SOME edge cases where this is useful, it's
-										 * mostly used for people to get more ad views. It's up to you but if you want
-										 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
-										 *
-										 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
-										 *
-										*/
-										wp_link_pages( array(
-											'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
-											'after'       => '</div>',
-											'link_before' => '<span>',
-											'link_after'  => '</span>',
-										) );
-									?>
-								</section> <!-- end article section -->
+								?></p>
 
-								<footer class="article-footer">
-									<p class="tags"><?php echo get_the_term_list( get_the_ID(), 'custom_tag', '<span class="tags-title">' . __( 'Custom Tags:', 'bonestheme' ) . '</span> ', ', ' ) ?></p>
+							</header>
 
-								</footer>
+							<section class="entry-content cf">
 
-								<?php comments_template(); ?>
+								<?php
+									// the content (pretty self explanatory huh)
+									the_content();
 
-							</article>
+									/*
+									 * Link Pages are used in case you have posts that are set to break into
+									 * multiple pages. You can remove this if you don't plan on doing that.
+									 *
+									 * Also, breaking content up into multiple pages is a horrible experience,
+									 * so don't do it. While there are SOME edge cases where this is useful, it's
+									 * mostly used for people to get more ad views. It's up to you but if you want
+									 * to do it, you're wrong and I hate you. (Ok, I still love you but just not as much)
+									 *
+									 * http://gizmodo.com/5841121/google-wants-to-help-you-avoid-stupid-annoying-multiple-page-articles
+									 *
+									*/
+									wp_link_pages( array(
+										'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'bonestheme' ) . '</span>',
+										'after'       => '</div>',
+										'link_before' => '<span>',
+										'link_after'  => '</span>',
+									) );
+								?>
 
-							<?php endwhile; ?>
+							</section>
 
-							<?php else : ?>
+							<footer class="article-footer">
 
-									<article id="post-not-found" class="hentry cf">
-										<header class="article-header">
-											<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
-										</header>
-										<section class="entry-content">
-											<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
-										</section>
-										<footer class="article-footer">
-											<p><?php _e( 'This is the error message in the single-custom_type.php template.', 'bonestheme' ); ?></p>
-										</footer>
-									</article>
+								<p class="tags"><?php echo get_the_term_list( get_the_ID(), 'custom_tag', '<span class="tags-title">' . __( 'Custom Tags:', 'bonestheme' ) . '</span> ', ', ' ) ?></p>
 
-							<?php endif; ?>
+							</footer>
 
-						</main>
+							<?php comments_template(); ?>
 
-						<?php get_sidebar(); ?>
+						</article>
+
+						<?php endwhile; ?>
+
+						<?php else : ?>
+
+						<article id="post-not-found" class="hentry cf">
+
+							<header class="article-header">
+
+								<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
+
+							</header>
+
+							<section class="entry-content">
+
+								<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
+
+							</section>
+
+							<footer class="article-footer">
+
+								<p><?php _e( 'This is the error message in the single-custom_type.php template.', 'bonestheme' ); ?></p>
+
+							</footer>
+
+						</article>
+
+						<?php endif; ?>
+
+					</main>
+
+					<?php get_sidebar(); ?>
 
 				</div>
 

--- a/single.php
+++ b/single.php
@@ -6,7 +6,7 @@
 
 					<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
 
-						<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+						<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 
 							<?php
 								/*
@@ -14,7 +14,6 @@
 								 *
 								 * So this function will bring in the needed template file depending on what the post
 								 * format is. The different post formats are located in the post-formats folder.
-								 *
 								 *
 								 * REMEMBER TO ALWAYS HAVE A DEFAULT ONE NAMED "format.php" FOR POSTS THAT AREN'T
 								 * A SPECIFIC POST FORMAT.
@@ -29,17 +28,27 @@
 
 						<?php else : ?>
 
-							<article id="post-not-found" class="hentry cf">
-									<header class="article-header">
-										<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
-									</header>
-									<section class="entry-content">
-										<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
-									</section>
-									<footer class="article-footer">
-											<p><?php _e( 'This is the error message in the single.php template.', 'bonestheme' ); ?></p>
-									</footer>
-							</article>
+						<article id="post-not-found" class="hentry cf">
+
+							<header class="article-header">
+
+								<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
+
+							</header>
+
+							<section class="entry-content">
+
+								<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
+
+							</section>
+
+							<footer class="article-footer">
+
+								<p><?php _e( 'This is the error message in the single.php template.', 'bonestheme' ); ?></p>
+
+							</footer>
+
+						</article>
 
 						<?php endif; ?>
 

--- a/taxonomy-custom_cat.php
+++ b/taxonomy-custom_cat.php
@@ -5,7 +5,7 @@
  * This is the custom post type taxonomy template. If you edit the custom taxonomy name,
  * you've got to change the name of this template to reflect that name change.
  *
- * For Example, if your custom taxonomy is called "register_taxonomy('shoes')",
+ * For example, if your custom taxonomy is called "register_taxonomy( 'shoes' )",
  * then your template name should be taxonomy-shoes.php
  *
  * For more info: http://codex.wordpress.org/Post_Type_Templates#Displaying_Custom_Taxonomies
@@ -18,57 +18,71 @@
 
 				<div id="inner-content" class="wrap cf">
 
-						<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
+					<main id="main" class="m-all t-2of3 d-5of7 cf" role="main" itemscope itemprop="mainContentOfPage" itemtype="http://schema.org/Blog">
 
-							<h1 class="archive-title h2"><span><?php _e( 'Posts Categorized:', 'bonestheme' ); ?></span> <?php single_cat_title(); ?></h1>
+						<h1 class="archive-title h2"><span><?php _e( 'Posts Categorized:', 'bonestheme' ); ?></span> <?php single_cat_title(); ?></h1>
 
-							<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+						<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
 
-							<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article">
+						<article id="post-<?php the_ID(); ?>" <?php post_class( 'cf' ); ?> role="article">
 
-								<header class="article-header">
+							<header class="article-header">
 
-									<h3 class="h2"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h3>
-									<p class="byline vcard"><?php
-										printf(__('Posted <time class="updated" datetime="%1$s" itemprop="datePublished">%2$s</time> by <span class="author">%3$s</span> <span class="amp">&</span> filed under %4$s.', 'bonestheme'), get_the_time('Y-m-j'), get_the_time(__('F jS, Y', 'bonestheme')), bones_get_the_author_posts_link(), get_the_term_list( get_the_ID(), 'custom_cat', "", ", ", "" ));
-									?></p>
+								<h3 class="h2"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h3>
 
-								</header>
+								<p class="byline vcard"><?php
 
-								<section class="entry-content">
-									<?php the_excerpt( '<span class="read-more">' . __( 'Read More &raquo;', 'bonestheme' ) . '</span>' ); ?>
+									printf( __( 'Posted <time class="updated" datetime="%1$s" itemprop="datePublished">%2$s</time> by <span class="author">%3$s</span> <span class="amp">&</span> filed under %4$s.', 'bonestheme'), get_the_time('Y-m-j'), get_the_time( __( 'F jS, Y', 'bonestheme' ) ), bones_get_the_author_posts_link(), get_the_term_list( get_the_ID(), 'custom_cat', "", ", ", "" ) );
 
-								</section>
+								?></p>
 
-								<footer class="article-footer">
+							</header>
 
-								</footer>
+							<section class="entry-content">
 
-							</article>
+								<?php the_excerpt( '<span class="read-more">' . __( 'Read More &raquo;', 'bonestheme' ) . '</span>' ); ?>
 
-							<?php endwhile; ?>
+							</section>
 
-									<?php bones_page_navi(); ?>
+							<footer class="article-footer">
 
-							<?php else : ?>
+							</footer>
 
-									<article id="post-not-found" class="hentry cf">
-										<header class="article-header">
-											<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
-										</header>
-										<section class="entry-content">
-											<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
-										</section>
-										<footer class="article-footer">
-												<p><?php _e( 'This is the error message in the taxonomy-custom_cat.php template.', 'bonestheme' ); ?></p>
-										</footer>
-									</article>
+						</article>
 
-							<?php endif; ?>
+						<?php endwhile; ?>
 
-						</main>
+						<?php bones_page_navi(); ?>
 
-						<?php get_sidebar(); ?>
+						<?php else : ?>
+
+						<article id="post-not-found" class="hentry cf">
+
+							<header class="article-header">
+
+								<h1><?php _e( 'Oops, Post Not Found!', 'bonestheme' ); ?></h1>
+
+							</header>
+
+							<section class="entry-content">
+
+								<p><?php _e( 'Uh Oh. Something is missing. Try double checking things.', 'bonestheme' ); ?></p>
+
+							</section>
+
+							<footer class="article-footer">
+
+								<p><?php _e( 'This is the error message in the taxonomy-custom_cat.php template.', 'bonestheme' ); ?></p>
+
+							</footer>
+
+						</article>
+
+					  <?php endif; ?>
+
+					</main>
+
+					<?php get_sidebar(); ?>
 
 				</div>
 


### PR DESCRIPTION
I noticed a few indentation bugs in the Bones template files, so I decided to fork the repo and clean them up. A few hours and several passes later, I think I've got things into much better and more consistent shape. Unfortunately these kinds of whitespace changes make the diff pretty gross, so it might be easier to review the individual template files, post-modification.

This is a pretty comprehensive list of the whitespace/indentation changes I made:

* Convert accidental spaces in indentation to tabs
* Fix indentation mistakes, misalignment
* Maintain HTML indentation level throughout templates (ie: avoid indenting html content inside php if-statements)
* Add blank lines between lines for readability (remove double/triple blank lines)
* Align php associative arrays around `=>`
* Use WordPress-style spacing before/after parentheses
* Eliminate whitespace between `<h1>`/`<p>` tags and `<?php` tags
* Remove redundant php comments, e.g. `</article> <?php // end article ?>`
* Fixed occasional typos, grammatical errors in comments
* Use PHP's "alternative control structure format", e.g. `if (true) : ... endif;` rather than curly brace-style

Also, after making those changes and running the resulting output through the HTML5 validator, I discovered a copy/paste bug where a span tag used in the byline had an erroneous attribute `itemptype` which should have been `itemtype` per https://html.spec.whatwg.org/multipage/dom.html#global-attributes

Finally I flipped on support for HTML5 in galleries and captions.

Let me know what you think.