### PR TITLE
Spell the abbreviation etc. correctly in comment

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@ URL: http://themble.com/bones/
 
 This is where you can drop your custom functions or
 just edit things like thumbnail sizes, header images,
-sidebars, comments, ect.
+sidebars, comments, etc.
 */
 
 // LOAD BONES CORE (if you remove this, the theme will break)


### PR DESCRIPTION
In the initial comment the abbreviation for the Latin phrase et cetera should be abbreviated etc. not ect.