### PR TITLE
by-line edit for 2 files

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -49,7 +49,7 @@
 
 									<h3 class="h2 entry-title"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h3>
 									<p class="byline entry-meta vcard">
-										<?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+										<?php printf( __( 'Posted %1$s %2$s', 'bonestheme' ),
                   							     /* the time the post was published */
                   							     '<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
                        								/* the author of the post */

--- a/index.php
+++ b/index.php
@@ -14,7 +14,7 @@
 
 									<h1 class="h2 entry-title"><a href="<?php the_permalink() ?>" rel="bookmark" title="<?php the_title_attribute(); ?>"><?php the_title(); ?></a></h1>
 									<p class="byline entry-meta vcard">
-                                        				<?php printf( __( 'Posted %1$s by %2$s', 'bonestheme' ),
+                                        				<?php printf( __( 'Posted %1$s %2$s', 'bonestheme' ),
                        								/* the time the post was published */
                        								'<time class="updated entry-time" datetime="' . get_the_time('Y-m-d') . '" itemprop="datePublished">' . get_the_time(get_option('date_format')) . '</time>',
                        								/* the author of the post */


### PR DESCRIPTION
Removed “by” from printf format string since there is an argument
containing the same word. This was causing duplicate “by” in by-line.