### PR TITLE
Make use of Google font protocol agnostic

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -239,7 +239,7 @@ can replace these fonts, change it in your scss files
 and be up and running in seconds.
 */
 function bones_fonts() {
-  wp_enqueue_style('googleFonts', 'http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic');
+  wp_enqueue_style('googleFonts', '//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic');
 }
 
 add_action('wp_enqueue_scripts', 'bones_fonts');


### PR DESCRIPTION
Make use of Google font protocol agnostic to avoid mixed content warnings on SSL sites.