### PR TITLE
A better practice border-box everything

### DIFF
--- a/library/scss/partials/_normalize.scss
+++ b/library/scss/partials/_normalize.scss
@@ -468,11 +468,12 @@ table {
 }
 
 
-// BORDER-BOX ALL THE THINGS! (http://paulirish.com/2012/box-sizing-border-box-ftw/)
-* {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing:    border-box;
-    box-sizing:         border-box;
+// BORDER-BOX ALL THE THINGS! (https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/)
+html {
+  box-sizing: border-box;
+}
+*, *:before, *:after {
+  box-sizing: inherit;
 }
 
 // http://www.zeldman.com/2012/03/01/replacing-the-9999px-hack-new-image-replacement/


### PR DESCRIPTION
This seems to be agreed as the best way of doing this as it allows setting an element and inherently it's children to a different box model in the odd case where one would need that.