### PR TITLE
Edit typo and update to markdown to ordered list

### DIFF
--- a/library/translation/README.md
+++ b/library/translation/README.md
@@ -6,10 +6,10 @@ A function in `functions.php` identifies the LOCALE (e.g. da_DK) of your WordPre
 
 ### How to translate bones to your language
 
-  1 Make a copy of `default.po` an change the filename to your LOCALE.po (e.g. `da_DK.mo`)
-  2 Use [poedit](http://www.poedit.net/ "home of poedit") to edit your po-file.
-  3 When saving your po-file, poedit will create/update a corresponding mo-file.
-  4 Please commit both your po- and mo-file. 
+  1. Make a copy of `default.po` and change the filename to your LOCALE.po (e.g. `da_DK.mo`)
+  2. Use [poedit](http://www.poedit.net/ "home of poedit") to edit your po-file.
+  3. When saving your po-file, poedit will create/update a corresponding mo-file.
+  4. Please commit both your po- and mo-file. 
 
 ### More
 


### PR DESCRIPTION
Update a type from 'an' to 'and' plus make the list a proper markdown list for better readability.